### PR TITLE
docs: update readme with example using multiple containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,36 @@ definition file to ECS:
         cluster: my-cluster
 ```
 
+If your task definition file holds multiple containers in the `containerDefs`
+section which require updated image URIs, chain multiple executions of this action
+together using the output value from the first action for the `task-definition`
+input of the second:
+
+```yaml
+    - name: Render Amazon ECS task definition for first container
+      id: render-web-container
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition.json
+        container-name: web
+        image: amazon/amazon-ecs-sample:latest
+
+    - name: Modify Amazon ECS task definition with second container
+      id: render-app-container
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: ${{ steps.render-web-container.outputs.task-definition }}
+        container-name: app
+        image: amazon/amazon-ecs-sample:latest
+
+    - name: Deploy to Amazon ECS service
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.render-app-container.outputs.task-definition }}
+        service: my-service
+        cluster: my-cluster
+```
+
 See [action.yml](action.yml) for the full documentation for this action's inputs
 and outputs.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## Amazon ECS "Render Task Definition" Action for GitHub Actions
 
-Inserts a container image URI into an Amazon ECS task definition JSON file, creating a new task definition file.
+Inserts a container image URI into an Amazon ECS task definition JSON file,
+creating a new task definition file.
 
 **Table of Contents**
 
@@ -14,7 +15,9 @@ Inserts a container image URI into an Amazon ECS task definition JSON file, crea
 
 ## Usage
 
-To insert the image URI `amazon/amazon-ecs-sample:latest` as the image for the `web` container in the task definition file, and then deploy the edited task definition file to ECS:
+To insert the image URI `amazon/amazon-ecs-sample:latest` as the image for the
+`web` container in the task definition file, and then deploy the edited task
+definition file to ECS:
 
 ```yaml
     - name: Render Amazon ECS task definition
@@ -33,7 +36,8 @@ To insert the image URI `amazon/amazon-ecs-sample:latest` as the image for the `
         cluster: my-cluster
 ```
 
-See [action.yml](action.yml) for the full documentation for this action's inputs and outputs.
+See [action.yml](action.yml) for the full documentation for this action's inputs
+and outputs.
 
 ## License Summary
 
@@ -41,4 +45,7 @@ This code is made available under the MIT license.
 
 ## Security Disclosures
 
-If you would like to report a potential security issue in this project, please do not create a GitHub issue.  Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).
+If you would like to report a potential security issue in this project, please
+do not create a GitHub issue.  Instead, please follow the instructions
+[here](https://aws.amazon.com/security/vulnerability-reporting/) or
+[email AWS security directly](mailto:aws-security@amazon.com).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ## Amazon ECS "Render Task Definition" Action for GitHub Actions
 
-Inserts a container image URI into an Amazon ECS task definition JSON file,
-creating a new task definition file.
+Inserts a container image URI into an Amazon ECS task definition JSON file, creating a new task definition file.
 
 **Table of Contents**
 
@@ -15,9 +14,7 @@ creating a new task definition file.
 
 ## Usage
 
-To insert the image URI `amazon/amazon-ecs-sample:latest` as the image for the
-`web` container in the task definition file, and then deploy the edited task
-definition file to ECS:
+To insert the image URI `amazon/amazon-ecs-sample:latest` as the image for the `web` container in the task definition file, and then deploy the edited task definition file to ECS:
 
 ```yaml
     - name: Render Amazon ECS task definition
@@ -66,8 +63,7 @@ input of the second:
         cluster: my-cluster
 ```
 
-See [action.yml](action.yml) for the full documentation for this action's inputs
-and outputs.
+See [action.yml](action.yml) for the full documentation for this action's inputs and outputs.
 
 ## License Summary
 
@@ -75,7 +71,4 @@ This code is made available under the MIT license.
 
 ## Security Disclosures
 
-If you would like to report a potential security issue in this project, please
-do not create a GitHub issue.  Instead, please follow the instructions
-[here](https://aws.amazon.com/security/vulnerability-reporting/) or
-[email AWS security directly](mailto:aws-security@amazon.com).
+If you would like to report a potential security issue in this project, please do not create a GitHub issue.  Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To insert the image URI `amazon/amazon-ecs-sample:latest` as the image for the `
         cluster: my-cluster
 ```
 
-If your task definition file holds multiple containers in the `containerDefs`
+If your task definition file holds multiple containers in the `containerDefinitions`
 section which require updated image URIs, chain multiple executions of this action
 together using the output value from the first action for the `task-definition`
 input of the second:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ input of the second:
       with:
         task-definition: task-definition.json
         container-name: web
-        image: amazon/amazon-ecs-sample:latest
+        image: amazon/amazon-ecs-sample-1:latest
 
     - name: Modify Amazon ECS task definition with second container
       id: render-app-container
@@ -56,7 +56,7 @@ input of the second:
       with:
         task-definition: ${{ steps.render-web-container.outputs.task-definition }}
         container-name: app
-        image: amazon/amazon-ecs-sample:latest
+        image: amazon/amazon-ecs-sample-2:latest
 
     - name: Deploy to Amazon ECS service
       uses: aws-actions/amazon-ecs-deploy-task-definition@v1


### PR DESCRIPTION
In #20 there is an example which shows the output of this action used as the task-definition input of another use of this action. I ran into a different use case for this type of usage today as I have a task definition which contains multiple containers which need to get updated URIs before I can deploy and update my service. Thought it would be useful to document this for other users to find.

Made a small modification to the README which describes how to use this action when the task definition contains multiple containers in the containerDefs section.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
