### PR TITLE
fix: use new tmp dir options in upgraded library

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ async function run() {
 
     // Write out a new task definition file
     var updatedTaskDefFile = tmp.fileSync({
-      dir: process.env.RUNNER_TEMP,
+      tmpdir: process.env.RUNNER_TEMP,
       prefix: 'task-definition-',
       postfix: '.json',
       keep: true,

--- a/index.test.js
+++ b/index.test.js
@@ -19,7 +19,7 @@ describe('Render task definition', () => {
             .mockReturnValueOnce('nginx:latest');        // image
 
         process.env = Object.assign(process.env, { GITHUB_WORKSPACE: __dirname });
-        process.env = Object.assign(process.env, { RUNNER_TEMP: '/tmp' });
+        process.env = Object.assign(process.env, { RUNNER_TEMP: '/home/runner/work/_temp' });
 
         tmp.fileSync.mockReturnValue({
             name: 'new-task-def-file-name'
@@ -45,7 +45,7 @@ describe('Render task definition', () => {
     test('renders the task definition and creates a new task def file', async () => {
         await run();
         expect(tmp.fileSync).toHaveBeenNthCalledWith(1, {
-            dir: '/tmp',
+            tmpdir: '/home/runner/work/_temp',
             prefix: 'task-definition-',
             postfix: '.json',
             keep: true,
@@ -88,7 +88,7 @@ describe('Render task definition', () => {
         await run();
 
         expect(tmp.fileSync).toHaveBeenNthCalledWith(1, {
-            dir: '/tmp',
+            tmpdir: '/home/runner/work/_temp',
             prefix: 'task-definition-',
             postfix: '.json',
             keep: true,


### PR DESCRIPTION
A recent upgrade of node-tmp made a breaking change to the options for writing a temporary file, resulting in a failing integration test:
https://github.com/aws-actions/amazon-ecs-render-task-definition/runs/661059140?check_suite_focus=true
This change uses the new node-tmp option for creating a file in a directory that is not /tmp.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
