### PR TITLE
feat: Parameter store and secrets manager handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To insert the image URI `amazon/amazon-ecs-sample:latest` as the image for the `
         task-definition: task-definition.json
         container-name: web
         image: amazon/amazon-ecs-sample:latest
-        secrets: true
+        secrets: external-secrets.json
         region-name: us-east-2
         aws-account-id: ${{ steps.aws-credentials-configuration.outputs.aws-account-id }}
 
@@ -75,22 +75,46 @@ input of the second:
 ```
 
 If you choose to add environment variables using the "secrets" input, add the "secrets" input
-and set it to `true` and your "region-name" in your GitHub workflow and add the secrets section to your 
+and set it to `true`, your AWS "region-name", and AWS account ID (from configure AWS credentials
+action) in your GitHub workflow and add the secrets section to your 
 [task definition](https://aws.amazon.com/premiumsupport/knowledge-center/ecs-data-security-container-task/).
+You can either use the task definition file, an external file, or both (the last two, you must specify the
+filename and have the secrets array in the containerDefinition).
 The "valueFrom" in your task definition should include this specific format:
 
 ```
 {
     "name": "var-from-parameter-store",
     "valueFrom": "ssm:/path/to/variable"
-}
+},
 {
     "name": "var-from-secrets-manager",
     "valueFrom": "secretsmanager:/path/to/variable"
 }
 ```
 
-Notice the "ssm" and "secretsmanager" prefix, both of which are followed by a ":" (colon) and variable path. The parameter path must start with "/" (a forward slash).
+If you use an external JSON file for secrets, then your secrets input
+should be the external JSON file and the file should have the format
+that must abide as follows:
+
+```
+{
+    secrets: [
+        {
+            "name": "var-from-parameter-store",
+            "valueFrom": "ssm:/path/to/variable"
+        },
+        {
+            "name": "var-from-secrets-manager",
+            "valueFrom": "secretsmanager:/path/to/variable"
+        }
+    ]
+}
+```
+
+Notice the "ssm" and "secretsmanager" prefix, both of which are followed by a ":" (colon) and variable path.
+The parameter path must start with "/" (a forward slash). You can have an external secrets JSON
+file AND secrets already inside of your task definition as they'll be combined. 
 
 See [action.yml](action.yml) for the full documentation for this action's inputs and outputs.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To insert the image URI `amazon/amazon-ecs-sample:latest` as the image for the `
       with:
         aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+        aws-region: us-east-2
 
     - name: Render Amazon ECS task definition
       id: render-web-container
@@ -33,7 +33,7 @@ To insert the image URI `amazon/amazon-ecs-sample:latest` as the image for the `
         container-name: web
         image: amazon/amazon-ecs-sample:latest
         secrets: external-secrets.json
-        region-name: us-east-2
+        aws-region: us-east-2
         aws-account-id: ${{ steps.aws-credentials-configuration.outputs.aws-account-id }}
 
     - name: Deploy to Amazon ECS service

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Inserts a container image URI into an Amazon ECS task definition JSON file, crea
 To insert the image URI `amazon/amazon-ecs-sample:latest` as the image for the `web` container in the task definition file, and then deploy the edited task definition file to ECS:
 
 ```yaml
+    - name: Configure AWS credentials from Test account
+      id: aws-credentials-configuration
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+
     - name: Render Amazon ECS task definition
       id: render-web-container
       uses: aws-actions/amazon-ecs-render-task-definition@v1
@@ -26,6 +34,7 @@ To insert the image URI `amazon/amazon-ecs-sample:latest` as the image for the `
         image: amazon/amazon-ecs-sample:latest
         secrets: true
         region-name: us-east-2
+        aws-account-id: ${{ steps.aws-credentials-configuration.outputs.aws-account-id }}
 
     - name: Deploy to Amazon ECS service
       uses: aws-actions/amazon-ecs-deploy-task-definition@v1

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ To insert the image URI `amazon/amazon-ecs-sample:latest` as the image for the `
         task-definition: task-definition.json
         container-name: web
         image: amazon/amazon-ecs-sample:latest
+        secrets: true
 
     - name: Deploy to Amazon ECS service
       uses: aws-actions/amazon-ecs-deploy-task-definition@v1
@@ -63,6 +64,24 @@ input of the second:
         cluster: my-cluster
 ```
 
+If you choose to add environment variables using the "secrets" input, add the secrets input
+and set it to `true` in your GitHub workflow and add the secrets section to your 
+[task definition](https://aws.amazon.com/premiumsupport/knowledge-center/ecs-data-security-container-task/).
+The "valueFrom" should include this specific format:
+
+```
+{
+    "name": "var-from-parameter-store",
+    "valueFrom": "ssm:path/to/variable"
+}
+{
+    "name": "var-from-secrets-manager",
+    "valueFrom": "secretsmanager:path/to/variable"
+}
+```
+
+Notice the "ssm" and "secretsmanager" prefix, both of which are followed by a ":" (colon) and variable path.
+
 See [action.yml](action.yml) for the full documentation for this action's inputs and outputs.
 
 ## License Summary
@@ -72,3 +91,4 @@ This code is made available under the MIT license.
 ## Security Disclosures
 
 If you would like to report a potential security issue in this project, please do not create a GitHub issue.  Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).
+

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ To insert the image URI `amazon/amazon-ecs-sample:latest` as the image for the `
         container-name: web
         image: amazon/amazon-ecs-sample:latest
         secrets: true
+        region-name: us-east-2
 
     - name: Deploy to Amazon ECS service
       uses: aws-actions/amazon-ecs-deploy-task-definition@v1
@@ -64,23 +65,23 @@ input of the second:
         cluster: my-cluster
 ```
 
-If you choose to add environment variables using the "secrets" input, add the secrets input
-and set it to `true` in your GitHub workflow and add the secrets section to your 
+If you choose to add environment variables using the "secrets" input, add the "secrets" input
+and set it to `true` and your "region-name" in your GitHub workflow and add the secrets section to your 
 [task definition](https://aws.amazon.com/premiumsupport/knowledge-center/ecs-data-security-container-task/).
-The "valueFrom" should include this specific format:
+The "valueFrom" in your task definition should include this specific format:
 
 ```
 {
     "name": "var-from-parameter-store",
-    "valueFrom": "ssm:path/to/variable"
+    "valueFrom": "ssm:/path/to/variable"
 }
 {
     "name": "var-from-secrets-manager",
-    "valueFrom": "secretsmanager:path/to/variable"
+    "valueFrom": "secretsmanager:/path/to/variable"
 }
 ```
 
-Notice the "ssm" and "secretsmanager" prefix, both of which are followed by a ":" (colon) and variable path.
+Notice the "ssm" and "secretsmanager" prefix, both of which are followed by a ":" (colon) and variable path. The parameter path must start with "/" (a forward slash).
 
 See [action.yml](action.yml) for the full documentation for this action's inputs and outputs.
 
@@ -91,4 +92,3 @@ This code is made available under the MIT license.
 ## Security Disclosures
 
 If you would like to report a potential security issue in this project, please do not create a GitHub issue.  Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).
-

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,15 @@ inputs:
   image:
     description: 'The URI of the container image to insert into the ECS task definition'
     required: true
+  secrets:
+    description: 'Whether to incorporate secrets from parameter store or secrets manager using pre-defined secrets in the task definition or from an external file'
+    required: false
+  aws-region:
+    description: 'AWS Region, e.g. us-east-2'
+    required: false
+  aws-account-id:
+    description: 'AWS Account ID'
+    required: false
 outputs:
   task-definition:
     description: 'The path to the rendered task definition file'

--- a/index.js
+++ b/index.js
@@ -1,89 +1,572 @@
-const path = require('path');
+const run = require('.');
 const core = require('@actions/core');
 const tmp = require('tmp');
 const fs = require('fs');
 
-async function run() {
-  try {
-    // Get inputs
-    const taskDefinitionFile = core.getInput('task-definition', { required: true });
-    const containerName = core.getInput('container-name', { required: true });
-    const imageURI = core.getInput('image', { required: true });
-    const secrets = core.getInput('secrets', { required: false });
-    const regionName = core.getInput('region-name', { required: false });
-    const accountID = core.getInput('aws-account-id', { required: false });
+jest.mock('@actions/core');
+jest.mock('tmp');
+jest.mock('fs');
 
-    // Parse the task definition
-    const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
-      taskDefinitionFile :
-      path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
-    if (!fs.existsSync(taskDefPath)) {
-      throw new Error(`Task definition file does not exist: ${taskDefinitionFile}`);
-    }
-    const taskDefContents = require(taskDefPath);
+describe('Render task definition', () => {
 
-    // Insert the image URI
-    if (!Array.isArray(taskDefContents.containerDefinitions)) {
-      throw new Error('Invalid task definition format: containerDefinitions section is not present or is not an array');
-    }
-    const containerDef = taskDefContents.containerDefinitions.find(function(element) {
-      return element.name == containerName;
-    });
-    if (!containerDef) {
-      throw new Error('Invalid task definition: Could not find container definition with matching name');
-    }
-    containerDef.image = imageURI;
+    beforeEach(() => {
+        jest.clearAllMocks();
 
-    // Insert any secrets from Parameter Store or Secrets Manager.
-    // Up to here, we know that the containerDefinition must exist
-    if (secrets && secrets.toLowerCase() === 'true') {
-        // Check the task definition if secrets section exists
-        if (!Array.isArray(containerDef.secrets)) {
-            throw new Error('Invalid task definition format: secrets section must be an array')
-        }
-        if (!regionName || !accountID) {
-            throw new Error('Invalid GitHub action input: You must specify the region name and the account ID.')
-        }
-        // Loop through array of, hopefully, dictionaries
-        containerDef.secrets.forEach(element => {
-            const valueFrom = element.valueFrom.split(":")
-            if (valueFrom.length != 2) {
-                // Detailed error since we're looping through.
-                throw new Error(`Invalid task definition: valueFrom format must be in the form of <service>:<path of variable>. Errored: ${valueFrom}`);
-            }
-            if (!['ssm', 'secretsmanager'].includes(valueFrom[0])) {
-                throw new Error(`Invalid task definition: valueFrom must have prefix ssm or secretsmanager, not ${valueFrom[0]}`)
-            }
-            if (valueFrom[1].charAt(0) != '/') {
-                valueFrom[1] = "/".concat(valueFrom[1])
-            }
-            element.valueFrom = `arn:aws:${valueFrom[0]}:${regionName}:${accountID}:${(valueFrom[0] == 'ssm') ? 'parameter' : 'secret'}${valueFrom[1]}`
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('task-definition.json') // task-definition
+            .mockReturnValueOnce('web')                  // container-name
+            .mockReturnValueOnce('nginx:latest');        // image
 
-            // Set executionRoleArn to use secrets section
-            taskDefContents.executionRoleArn = `arn:aws:iam::${accountID}:role/ecsTaskExecutionRole`
+        process.env = Object.assign(process.env, { GITHUB_WORKSPACE: __dirname });
+        process.env = Object.assign(process.env, { RUNNER_TEMP: '/home/runner/work/_temp' });
+
+        tmp.fileSync.mockReturnValue({
+            name: 'new-task-def-file-name'
         });
-    }
 
-    // Write out a new task definition file
-    var updatedTaskDefFile = tmp.fileSync({
-      tmpdir: process.env.RUNNER_TEMP,
-      prefix: 'task-definition-',
-      postfix: '.json',
-      keep: true,
-      discardDescriptor: true
+        fs.existsSync.mockReturnValue(true);
+
+        jest.mock('./task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image"
+                },
+                {
+                    name: "sidecar",
+                    image: "hello"
+                }
+            ]
+        }), { virtual: true });
     });
-    const newTaskDefContents = JSON.stringify(taskDefContents, null, 2);
-    fs.writeFileSync(updatedTaskDefFile.name, newTaskDefContents);
-    core.setOutput('task-definition', updatedTaskDefFile.name);
-  }
-  catch (error) {
-    core.setFailed(error.message);
-  }
-}
 
-module.exports = run;
+    test('renders the task definition and creates a new task def file', async () => {
+        await run();
+        expect(tmp.fileSync).toHaveBeenNthCalledWith(1, {
+            tmpdir: '/home/runner/work/_temp',
+            prefix: 'task-definition-',
+            postfix: '.json',
+            keep: true,
+            discardDescriptor: true
+          });
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest"
+                    },
+                    {
+                        name: "sidecar",
+                        image: "hello"
+                    }
+                ]
+            }, null, 2)
+        );
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
+    });
 
-/* istanbul ignore next */
-if (require.main === module) {
-    run();
-}
+    test('renders a task definition at an absolute path', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('/hello/task-definition.json') // task-definition
+            .mockReturnValueOnce('web')                  // container-name
+            .mockReturnValueOnce('nginx:latest');        // image
+        jest.mock('/hello/task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image"
+                }
+            ]
+        }), { virtual: true });
+
+        await run();
+
+        expect(tmp.fileSync).toHaveBeenNthCalledWith(1, {
+            tmpdir: '/home/runner/work/_temp',
+            prefix: 'task-definition-',
+            postfix: '.json',
+            keep: true,
+            discardDescriptor: true
+          });
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest"
+                    }
+                ]
+            }, null, 2)
+        );
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
+    });
+
+    test('error returned for missing task definition file', async () => {
+        fs.existsSync.mockReturnValue(false);
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('does-not-exist-task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest');
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Task definition file does not exist: does-not-exist-task-definition.json');
+    });
+
+    test('error returned for non-JSON task definition contents', async () => {
+        jest.mock('./non-json-task-definition.json', () => ("hello"), { virtual: true });
+
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('non-json-task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest');
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid task definition format: containerDefinitions section is not present or is not an array');
+    });
+
+    test('error returned for malformed task definition with non-array container definition section', async () => {
+        jest.mock('./malformed-task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: {}
+        }), { virtual: true });
+
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('malformed-task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest');
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid task definition format: containerDefinitions section is not present or is not an array');
+    });
+
+    test('error returned for task definition without matching container name', async () => {
+        jest.mock('./missing-container-task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "main",
+                    image: "some-other-image"
+                }
+            ]
+        }), { virtual: true });
+
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('missing-container-task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest');
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid task definition: Could not find container definition with matching name');
+    });
+
+    // Secrets section
+
+    test('error returned for malformed task definition with missing secrets section', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest')
+            .mockReturnValueOnce('true')
+            .mockReturnValueOnce('us-east-2')
+            .mockReturnValueOnce(1234);
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid task definition format: secrets section must be an array');
+    });
+
+    test('error returned for missing AWS account ID if secrets is turned on', async () => {
+        jest.mock('./correct-secrets-task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image",
+                    secrets: [
+                        {
+                            name: "SomeEnvironmentVarName",
+                            valueFrom: "ssm:/qwop/blah"
+                        },
+                        {
+                            name: "Yoomzzzzzz",
+                            valueFrom: "ssm:/qwerty/qwerty"
+                        }
+                    ]
+                }
+            ]
+        }), { virtual: true });
+
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('correct-secrets-task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest')
+            .mockReturnValueOnce('true')
+            .mockReturnValueOnce('us-east-2')
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid GitHub action input: You must specify the region name and the account ID');
+    });
+
+    test('error returned for missing region name if secrets is turned on', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('correct-secrets-task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest')
+            .mockReturnValueOnce('true')
+            .mockReturnValueOnce(1234)
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid GitHub action input: You must specify the region name and the account ID');
+    });
+
+    // Testing valueFrom format
+    test('error returned for incorrect valueFrom prefix in secrets section', async () => {
+        jest.mock('./incorrect-valueFrom-prefix-task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image",
+                    secrets: [
+                        {
+                            name: "someEnvironName",
+                            valueFrom: "randomService:/asd/asd"
+                        }
+                    ]
+                }
+            ]
+        }), { virtual: true });
+
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('incorrect-valueFrom-prefix-task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest')
+            .mockReturnValueOnce('true')
+            .mockReturnValueOnce('us-east-2')
+            .mockReturnValueOnce(12345);
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid task definition: valueFrom must have prefix ssm or secretsmanager, not randomService');
+    });
+
+    test('error returned for incorrect valueFrom format in secrets section', async () => {
+        jest.mock('./incorrect-valueFrom-format-task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image",
+                    secrets: [
+                        {
+                            name: "someEnvironName",
+                            valueFrom: "randomService"
+                        },
+                        {
+                            name: "someEnvironName",
+                            valueFrom: "randomService"
+                        }
+                    ]
+                }
+            ]
+        }), { virtual: true });
+
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('incorrect-valueFrom-format-task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest')
+            .mockReturnValueOnce('true')
+            .mockReturnValueOnce('us-east-2')
+            .mockReturnValueOnce(1234);
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid task definition: valueFrom format must be in the form of <service>:<path of variable>. Errored: randomService');
+    });
+
+    test('insert / at beginning of parameter path if / is not there', async () => {
+        jest.mock('./missing-beginning-slash-param-path-task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image",
+                    secrets: [
+                        {
+                            name: "someEnvironName",
+                            valueFrom: "ssm:asd/asd"
+                        }
+                    ]
+                }
+            ]
+        }), { virtual: true });
+
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('missing-beginning-slash-param-path-task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest')
+            .mockReturnValueOnce('true')
+            .mockReturnValueOnce('us-east-2')
+            .mockReturnValueOnce(1234);
+
+        await run();
+
+        expect(tmp.fileSync).toHaveBeenNthCalledWith(1, {
+            tmpdir: '/home/runner/work/_temp',
+            prefix: 'task-definition-',
+            postfix: '.json',
+            keep: true,
+            discardDescriptor: true
+          });
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest",
+                        secrets: [
+                            {
+                                name: "someEnvironName",
+                                valueFrom: 'arn:aws:ssm:us-east-2:1234:parameter/asd/asd'
+                            }
+                        ]
+                    }
+                ],
+                executionRoleArn: 'arn:aws:iam::1234:role/ecsTaskExecutionRole'
+            }, null, 2)
+        );
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
+    });
+
+    // Testing external secrets file insertion
+    test('insert external secrets file into secrets', async () => {
+        jest.mock('./two-external-secrets.json', () => ({
+            secrets: [
+                {
+                    "name": "external1",
+                    "valueFrom": "ssm:blah"
+                },
+                {
+                    "name": "external2",
+                    "valueFrom": "ssm:blah2"
+                }
+            ]
+        }), { virtual: true });
+
+        jest.mock('./empty-secrets-array-task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image"
+                }
+            ]
+        }), { virtual: true });
+
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('empty-secrets-array-task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest')
+            .mockReturnValueOnce('two-external-secrets.json')
+            .mockReturnValueOnce('us-east-2')
+            .mockReturnValueOnce(1234);
+
+        await run();
+
+        expect(tmp.fileSync).toHaveBeenNthCalledWith(1, {
+            tmpdir: '/home/runner/work/_temp',
+            prefix: 'task-definition-',
+            postfix: '.json',
+            keep: true,
+            discardDescriptor: true
+          });
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest",
+                        secrets: [
+                            {
+                                name: "external1",
+                                valueFrom: "arn:aws:ssm:us-east-2:1234:parameter/blah"
+                            },
+                            {
+                                name: "external2",
+                                valueFrom: "arn:aws:ssm:us-east-2:1234:parameter/blah2"
+                            }
+                        ]
+                    }
+                ],
+                executionRoleArn: 'arn:aws:iam::1234:role/ecsTaskExecutionRole'
+            }, null, 2)
+        );
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
+    });
+
+    test('insert external secrets file into secrets which already has secrets in task definition', async () => {
+        // Makes sure the secrets are combined.
+        jest.mock('./three-external-secrets.json', () => ({
+            secrets: [
+                {
+                    "name": "external1",
+                    "valueFrom": "ssm:blah"
+                },
+                {
+                    "name": "external2",
+                    "valueFrom": "secretsmanager:/blah2"
+                },
+                {
+                    "name": "external3",
+                    "valueFrom": "secretsmanager:/blah/blah"
+                }
+            ]
+        }), { virtual: true });
+
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('correct-secrets-task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest')
+            .mockReturnValueOnce('three-external-secrets.json')
+            .mockReturnValueOnce('us-east-2')
+            .mockReturnValueOnce(1234);
+
+        await run();
+
+        expect(tmp.fileSync).toHaveBeenNthCalledWith(1, {
+            tmpdir: '/home/runner/work/_temp',
+            prefix: 'task-definition-',
+            postfix: '.json',
+            keep: true,
+            discardDescriptor: true
+          });
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest",
+                        secrets: [
+                            {
+                                name: "SomeEnvironmentVarName",
+                                valueFrom: "arn:aws:ssm:us-east-2:1234:parameter/qwop/blah"
+                            },
+                            {
+                                name: "Yoomzzzzzz",
+                                valueFrom: "arn:aws:ssm:us-east-2:1234:parameter/qwerty/qwerty"
+                            },
+                            {
+                                name: "external1",
+                                valueFrom: "arn:aws:ssm:us-east-2:1234:parameter/blah"
+                            },
+                            {
+                                name: "external2",
+                                valueFrom: "arn:aws:secretsmanager:us-east-2:1234:secret/blah2"
+                            },
+                            {
+                                name: "external3",
+                                valueFrom: "arn:aws:secretsmanager:us-east-2:1234:secret/blah/blah"
+                            }
+                        ]
+                    }
+                ],
+                executionRoleArn: 'arn:aws:iam::1234:role/ecsTaskExecutionRole'
+            }, null, 2)
+        );
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
+    });
+
+    test('error returned for non-array secrets section', async () => {
+        jest.mock('./non-array-secrets-task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image",
+                    secrets: {
+                        name: "SomeEnvironmentVarName",
+                        valueFrom: "ssm:/qwop/blah"
+                    }
+                }
+            ]
+        }), { virtual: true });
+
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('non-array-secrets-task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest')
+            .mockReturnValueOnce('three-external-secrets.json')
+            .mockReturnValueOnce('us-east-2')
+            .mockReturnValue('1234')
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid task definition format: secrets section must be an array');
+    });
+
+    test('error returned for invalid external secrets json file format', async () => {
+        jest.mock('./invalid-external-secrets-file.json', () => ({
+            secrets: {
+                "name": "external1",
+                "valueFrom": "ssm:blah"
+            }
+        }), { virtual: true });
+
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('correct-secrets-task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest')
+            .mockReturnValueOnce('invalid-external-secrets-file.json')
+            .mockReturnValueOnce('us-east-2')
+            .mockReturnValueOnce(1234);
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid external secrets file: secrets section must be an array');
+    });
+
+    test('error returned for missing external secrets file', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('correct-secrets-task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest')
+            .mockReturnValueOnce('missing-external-secrets-file.json')
+            .mockReturnValueOnce('us-east-2')
+            .mockReturnValueOnce(1234);
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Secrets file does not exist: missing-external-secrets-file.json');
+    });
+});

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ async function run() {
     const taskDefinitionFile = core.getInput('task-definition', { required: true });
     const containerName = core.getInput('container-name', { required: true });
     const imageURI = core.getInput('image', { required: true });
+    const secrets = core.getInput('secrets', { required: false });
 
     // Parse the task definition
     const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
@@ -30,6 +31,23 @@ async function run() {
       throw new Error('Invalid task definition: Could not find container definition with matching name');
     }
     containerDef.image = imageURI;
+
+    // Insert any secrets from Parameter Store or Secrets Manager.
+    // Up to here, we know that the containerDefinition must exist
+    if (secrets && secrets.toLowerCase() === 'true') {
+        // Check the task definition if secrets section exists
+        if (!Array.isArray(containerDef.secrets)) {
+            throw new Error('Invalid task definition format: secrets section must be an array')
+        }
+        // Loop through array of, hopefully, dictionaries
+        containerDef.secrets.forEach(element => {
+            const valueFrom = element.valueFrom(":")
+            if (valueFrom.length != 2) {
+                throw new Error('Invalid task definition: valueFrom format must be in the form of <service>:<path of variable>');
+            }
+            element.valueFrom = "arn:aws:".concat(valueFrom[0], ":::", "region name", ":", "accountID", ":", valueFrom[1])
+        });
+    }
 
     // Write out a new task definition file
     var updatedTaskDefFile = tmp.fileSync({

--- a/index.js
+++ b/index.js
@@ -1,572 +1,126 @@
-const run = require('.');
+const path = require('path');
 const core = require('@actions/core');
 const tmp = require('tmp');
 const fs = require('fs');
 
-jest.mock('@actions/core');
-jest.mock('tmp');
-jest.mock('fs');
+async function run() {
+  try {
+    // Get inputs
+    const taskDefinitionFile = core.getInput('task-definition', { required: true });
+    const containerName = core.getInput('container-name', { required: true });
+    const imageURI = core.getInput('image', { required: true });
+    const secrets = core.getInput('secrets', { required: false });
+    const regionName = core.getInput('aws-region', { required: false });
+    const accountID = core.getInput('aws-account-id', { required: false });
 
-describe('Render task definition', () => {
+    // Parse the task definition
+    const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
+      taskDefinitionFile :
+      path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
+    if (!fs.existsSync(taskDefPath)) {
+      throw new Error(`Task definition file does not exist: ${taskDefinitionFile}`);
+    }
+    const taskDefContents = require(taskDefPath);
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('task-definition.json') // task-definition
-            .mockReturnValueOnce('web')                  // container-name
-            .mockReturnValueOnce('nginx:latest');        // image
-
-        process.env = Object.assign(process.env, { GITHUB_WORKSPACE: __dirname });
-        process.env = Object.assign(process.env, { RUNNER_TEMP: '/home/runner/work/_temp' });
-
-        tmp.fileSync.mockReturnValue({
-            name: 'new-task-def-file-name'
-        });
-
-        fs.existsSync.mockReturnValue(true);
-
-        jest.mock('./task-definition.json', () => ({
-            family: 'task-def-family',
-            containerDefinitions: [
-                {
-                    name: "web",
-                    image: "some-other-image"
-                },
-                {
-                    name: "sidecar",
-                    image: "hello"
-                }
-            ]
-        }), { virtual: true });
+    // Insert the image URI
+    if (!Array.isArray(taskDefContents.containerDefinitions)) {
+      throw new Error('Invalid task definition format: containerDefinitions section is not present or is not an array');
+    }
+    const containerDef = taskDefContents.containerDefinitions.find(function(element) {
+      return element.name == containerName;
     });
+    if (!containerDef) {
+      throw new Error('Invalid task definition: Could not find container definition with matching name');
+    }
+    containerDef.image = imageURI;
 
-    test('renders the task definition and creates a new task def file', async () => {
-        await run();
-        expect(tmp.fileSync).toHaveBeenNthCalledWith(1, {
-            tmpdir: '/home/runner/work/_temp',
-            prefix: 'task-definition-',
-            postfix: '.json',
-            keep: true,
-            discardDescriptor: true
-          });
-        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
-            JSON.stringify({
-                family: 'task-def-family',
-                containerDefinitions: [
-                    {
-                        name: "web",
-                        image: "nginx:latest"
-                    },
-                    {
-                        name: "sidecar",
-                        image: "hello"
+    // Insert any secrets ARN from Parameter Store or Secrets Manager.
+    /*
+    Up to here, we know that the containerDefinition must exist.
+    First, we insert the secrets from the external file.
+    */
+    if (secrets) {
+        if (!regionName || !accountID) {
+            throw new Error('Invalid GitHub action input: You must specify the region name and the account ID')
+        }
+
+        // Get the external secrets
+        if (secrets.toLowerCase() != 'true') {
+            const secretsPath = path.isAbsolute(secrets) ?
+              secrets :
+              path.join(process.env.GITHUB_WORKSPACE, secrets);
+            try {
+                // FIXME Workaround for existSync since tests weren't passing with existSync.
+                const secretsContent = require(secretsPath);
+                if (!Array.isArray(secretsContent.secrets)) {
+                    throw new Error('Invalid external secrets file: secrets section must be an array')
+                }
+                if (containerDef.secrets) {
+                    // Some secrets already exist in task definition.
+                    if (!Array.isArray(containerDef.secrets)) {
+                        throw new Error('Invalid task definition format: secrets section must be an array')
                     }
-                ]
-            }, null, 2)
-        );
-        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
-    });
-
-    test('renders a task definition at an absolute path', async () => {
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('/hello/task-definition.json') // task-definition
-            .mockReturnValueOnce('web')                  // container-name
-            .mockReturnValueOnce('nginx:latest');        // image
-        jest.mock('/hello/task-definition.json', () => ({
-            family: 'task-def-family',
-            containerDefinitions: [
-                {
-                    name: "web",
-                    image: "some-other-image"
-                }
-            ]
-        }), { virtual: true });
-
-        await run();
-
-        expect(tmp.fileSync).toHaveBeenNthCalledWith(1, {
-            tmpdir: '/home/runner/work/_temp',
-            prefix: 'task-definition-',
-            postfix: '.json',
-            keep: true,
-            discardDescriptor: true
-          });
-        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
-            JSON.stringify({
-                family: 'task-def-family',
-                containerDefinitions: [
-                    {
-                        name: "web",
-                        image: "nginx:latest"
+                    for (var i = 0, len = secretsContent.secrets.length; i < len; i++) {
+                        containerDef.secrets.push(secretsContent.secrets[i])
                     }
-                ]
-            }, null, 2)
-        );
-        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
-    });
-
-    test('error returned for missing task definition file', async () => {
-        fs.existsSync.mockReturnValue(false);
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('does-not-exist-task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest');
-
-        await run();
-
-        expect(core.setFailed).toBeCalledWith('Task definition file does not exist: does-not-exist-task-definition.json');
-    });
-
-    test('error returned for non-JSON task definition contents', async () => {
-        jest.mock('./non-json-task-definition.json', () => ("hello"), { virtual: true });
-
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('non-json-task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest');
-
-        await run();
-
-        expect(core.setFailed).toBeCalledWith('Invalid task definition format: containerDefinitions section is not present or is not an array');
-    });
-
-    test('error returned for malformed task definition with non-array container definition section', async () => {
-        jest.mock('./malformed-task-definition.json', () => ({
-            family: 'task-def-family',
-            containerDefinitions: {}
-        }), { virtual: true });
-
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('malformed-task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest');
-
-        await run();
-
-        expect(core.setFailed).toBeCalledWith('Invalid task definition format: containerDefinitions section is not present or is not an array');
-    });
-
-    test('error returned for task definition without matching container name', async () => {
-        jest.mock('./missing-container-task-definition.json', () => ({
-            family: 'task-def-family',
-            containerDefinitions: [
-                {
-                    name: "main",
-                    image: "some-other-image"
+                } else {
+                    containerDef.secrets = secretsContent.secrets
                 }
-            ]
-        }), { virtual: true });
-
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('missing-container-task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest');
-
-        await run();
-
-        expect(core.setFailed).toBeCalledWith('Invalid task definition: Could not find container definition with matching name');
-    });
-
-    // Secrets section
-
-    test('error returned for malformed task definition with missing secrets section', async () => {
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest')
-            .mockReturnValueOnce('true')
-            .mockReturnValueOnce('us-east-2')
-            .mockReturnValueOnce(1234);
-
-        await run();
-
-        expect(core.setFailed).toBeCalledWith('Invalid task definition format: secrets section must be an array');
-    });
-
-    test('error returned for missing AWS account ID if secrets is turned on', async () => {
-        jest.mock('./correct-secrets-task-definition.json', () => ({
-            family: 'task-def-family',
-            containerDefinitions: [
-                {
-                    name: "web",
-                    image: "some-other-image",
-                    secrets: [
-                        {
-                            name: "SomeEnvironmentVarName",
-                            valueFrom: "ssm:/qwop/blah"
-                        },
-                        {
-                            name: "Yoomzzzzzz",
-                            valueFrom: "ssm:/qwerty/qwerty"
-                        }
-                    ]
+            } catch (e) {
+                if (e.code == 'MODULE_NOT_FOUND') {
+                    throw new Error(`Secrets file does not exist: ${secrets}`);
+                } else {
+                    throw new Error(e.message)
                 }
-            ]
-        }), { virtual: true });
-
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('correct-secrets-task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest')
-            .mockReturnValueOnce('true')
-            .mockReturnValueOnce('us-east-2')
-
-        await run();
-
-        expect(core.setFailed).toBeCalledWith('Invalid GitHub action input: You must specify the region name and the account ID');
-    });
-
-    test('error returned for missing region name if secrets is turned on', async () => {
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('correct-secrets-task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest')
-            .mockReturnValueOnce('true')
-            .mockReturnValueOnce(1234)
-
-        await run();
-
-        expect(core.setFailed).toBeCalledWith('Invalid GitHub action input: You must specify the region name and the account ID');
-    });
-
-    // Testing valueFrom format
-    test('error returned for incorrect valueFrom prefix in secrets section', async () => {
-        jest.mock('./incorrect-valueFrom-prefix-task-definition.json', () => ({
-            family: 'task-def-family',
-            containerDefinitions: [
-                {
-                    name: "web",
-                    image: "some-other-image",
-                    secrets: [
-                        {
-                            name: "someEnvironName",
-                            valueFrom: "randomService:/asd/asd"
-                        }
-                    ]
-                }
-            ]
-        }), { virtual: true });
-
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('incorrect-valueFrom-prefix-task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest')
-            .mockReturnValueOnce('true')
-            .mockReturnValueOnce('us-east-2')
-            .mockReturnValueOnce(12345);
-
-        await run();
-
-        expect(core.setFailed).toBeCalledWith('Invalid task definition: valueFrom must have prefix ssm or secretsmanager, not randomService');
-    });
-
-    test('error returned for incorrect valueFrom format in secrets section', async () => {
-        jest.mock('./incorrect-valueFrom-format-task-definition.json', () => ({
-            family: 'task-def-family',
-            containerDefinitions: [
-                {
-                    name: "web",
-                    image: "some-other-image",
-                    secrets: [
-                        {
-                            name: "someEnvironName",
-                            valueFrom: "randomService"
-                        },
-                        {
-                            name: "someEnvironName",
-                            valueFrom: "randomService"
-                        }
-                    ]
-                }
-            ]
-        }), { virtual: true });
-
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('incorrect-valueFrom-format-task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest')
-            .mockReturnValueOnce('true')
-            .mockReturnValueOnce('us-east-2')
-            .mockReturnValueOnce(1234);
-
-        await run();
-
-        expect(core.setFailed).toBeCalledWith('Invalid task definition: valueFrom format must be in the form of <service>:<path of variable>. Errored: randomService');
-    });
-
-    test('insert / at beginning of parameter path if / is not there', async () => {
-        jest.mock('./missing-beginning-slash-param-path-task-definition.json', () => ({
-            family: 'task-def-family',
-            containerDefinitions: [
-                {
-                    name: "web",
-                    image: "some-other-image",
-                    secrets: [
-                        {
-                            name: "someEnvironName",
-                            valueFrom: "ssm:asd/asd"
-                        }
-                    ]
-                }
-            ]
-        }), { virtual: true });
-
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('missing-beginning-slash-param-path-task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest')
-            .mockReturnValueOnce('true')
-            .mockReturnValueOnce('us-east-2')
-            .mockReturnValueOnce(1234);
-
-        await run();
-
-        expect(tmp.fileSync).toHaveBeenNthCalledWith(1, {
-            tmpdir: '/home/runner/work/_temp',
-            prefix: 'task-definition-',
-            postfix: '.json',
-            keep: true,
-            discardDescriptor: true
-          });
-        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
-            JSON.stringify({
-                family: 'task-def-family',
-                containerDefinitions: [
-                    {
-                        name: "web",
-                        image: "nginx:latest",
-                        secrets: [
-                            {
-                                name: "someEnvironName",
-                                valueFrom: 'arn:aws:ssm:us-east-2:1234:parameter/asd/asd'
-                            }
-                        ]
-                    }
-                ],
-                executionRoleArn: 'arn:aws:iam::1234:role/ecsTaskExecutionRole'
-            }, null, 2)
-        );
-        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
-    });
-
-    // Testing external secrets file insertion
-    test('insert external secrets file into secrets', async () => {
-        jest.mock('./two-external-secrets.json', () => ({
-            secrets: [
-                {
-                    "name": "external1",
-                    "valueFrom": "ssm:blah"
-                },
-                {
-                    "name": "external2",
-                    "valueFrom": "ssm:blah2"
-                }
-            ]
-        }), { virtual: true });
-
-        jest.mock('./empty-secrets-array-task-definition.json', () => ({
-            family: 'task-def-family',
-            containerDefinitions: [
-                {
-                    name: "web",
-                    image: "some-other-image"
-                }
-            ]
-        }), { virtual: true });
-
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('empty-secrets-array-task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest')
-            .mockReturnValueOnce('two-external-secrets.json')
-            .mockReturnValueOnce('us-east-2')
-            .mockReturnValueOnce(1234);
-
-        await run();
-
-        expect(tmp.fileSync).toHaveBeenNthCalledWith(1, {
-            tmpdir: '/home/runner/work/_temp',
-            prefix: 'task-definition-',
-            postfix: '.json',
-            keep: true,
-            discardDescriptor: true
-          });
-        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
-            JSON.stringify({
-                family: 'task-def-family',
-                containerDefinitions: [
-                    {
-                        name: "web",
-                        image: "nginx:latest",
-                        secrets: [
-                            {
-                                name: "external1",
-                                valueFrom: "arn:aws:ssm:us-east-2:1234:parameter/blah"
-                            },
-                            {
-                                name: "external2",
-                                valueFrom: "arn:aws:ssm:us-east-2:1234:parameter/blah2"
-                            }
-                        ]
-                    }
-                ],
-                executionRoleArn: 'arn:aws:iam::1234:role/ecsTaskExecutionRole'
-            }, null, 2)
-        );
-        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
-    });
-
-    test('insert external secrets file into secrets which already has secrets in task definition', async () => {
-        // Makes sure the secrets are combined.
-        jest.mock('./three-external-secrets.json', () => ({
-            secrets: [
-                {
-                    "name": "external1",
-                    "valueFrom": "ssm:blah"
-                },
-                {
-                    "name": "external2",
-                    "valueFrom": "secretsmanager:/blah2"
-                },
-                {
-                    "name": "external3",
-                    "valueFrom": "secretsmanager:/blah/blah"
-                }
-            ]
-        }), { virtual: true });
-
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('correct-secrets-task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest')
-            .mockReturnValueOnce('three-external-secrets.json')
-            .mockReturnValueOnce('us-east-2')
-            .mockReturnValueOnce(1234);
-
-        await run();
-
-        expect(tmp.fileSync).toHaveBeenNthCalledWith(1, {
-            tmpdir: '/home/runner/work/_temp',
-            prefix: 'task-definition-',
-            postfix: '.json',
-            keep: true,
-            discardDescriptor: true
-          });
-        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
-            JSON.stringify({
-                family: 'task-def-family',
-                containerDefinitions: [
-                    {
-                        name: "web",
-                        image: "nginx:latest",
-                        secrets: [
-                            {
-                                name: "SomeEnvironmentVarName",
-                                valueFrom: "arn:aws:ssm:us-east-2:1234:parameter/qwop/blah"
-                            },
-                            {
-                                name: "Yoomzzzzzz",
-                                valueFrom: "arn:aws:ssm:us-east-2:1234:parameter/qwerty/qwerty"
-                            },
-                            {
-                                name: "external1",
-                                valueFrom: "arn:aws:ssm:us-east-2:1234:parameter/blah"
-                            },
-                            {
-                                name: "external2",
-                                valueFrom: "arn:aws:secretsmanager:us-east-2:1234:secret/blah2"
-                            },
-                            {
-                                name: "external3",
-                                valueFrom: "arn:aws:secretsmanager:us-east-2:1234:secret/blah/blah"
-                            }
-                        ]
-                    }
-                ],
-                executionRoleArn: 'arn:aws:iam::1234:role/ecsTaskExecutionRole'
-            }, null, 2)
-        );
-        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
-    });
-
-    test('error returned for non-array secrets section', async () => {
-        jest.mock('./non-array-secrets-task-definition.json', () => ({
-            family: 'task-def-family',
-            containerDefinitions: [
-                {
-                    name: "web",
-                    image: "some-other-image",
-                    secrets: {
-                        name: "SomeEnvironmentVarName",
-                        valueFrom: "ssm:/qwop/blah"
-                    }
-                }
-            ]
-        }), { virtual: true });
-
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('non-array-secrets-task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest')
-            .mockReturnValueOnce('three-external-secrets.json')
-            .mockReturnValueOnce('us-east-2')
-            .mockReturnValue('1234')
-
-        await run();
-
-        expect(core.setFailed).toBeCalledWith('Invalid task definition format: secrets section must be an array');
-    });
-
-    test('error returned for invalid external secrets json file format', async () => {
-        jest.mock('./invalid-external-secrets-file.json', () => ({
-            secrets: {
-                "name": "external1",
-                "valueFrom": "ssm:blah"
             }
-        }), { virtual: true });
+        } else {
+            // Check the task definition if secrets section exists
+            // It at least must be empty.
+            if (!Array.isArray(containerDef.secrets)) {
+                throw new Error('Invalid task definition format: secrets section must be an array')
+            }
+        }
 
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('correct-secrets-task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest')
-            .mockReturnValueOnce('invalid-external-secrets-file.json')
-            .mockReturnValueOnce('us-east-2')
-            .mockReturnValueOnce(1234);
+        // Loop through array of, hopefully, dictionaries in task def
+        containerDef.secrets.forEach(element => {
+            const valueFrom = element.valueFrom.split(":")
+            if (valueFrom.length != 2) {
+                // Detailed error since we're looping through.
+                throw new Error(`Invalid task definition: valueFrom format must be in the form of <service>:<path of variable>. Errored: ${valueFrom}`);
+            }
+            if (!['ssm', 'secretsmanager'].includes(valueFrom[0])) {
+                throw new Error(`Invalid task definition: valueFrom must have prefix ssm or secretsmanager, not ${valueFrom[0]}`)
+            }
+            if (valueFrom[1].charAt(0) != '/') {
+                valueFrom[1] = "/".concat(valueFrom[1])
+            }
+            element.valueFrom = `arn:aws:${valueFrom[0]}:${regionName}:${accountID}:${(valueFrom[0] == 'ssm') ? 'parameter' : 'secret'}${valueFrom[1]}`
 
-        await run();
+            // Set executionRoleArn to use secrets section
+            taskDefContents.executionRoleArn = `arn:aws:iam::${accountID}:role/ecsTaskExecutionRole`
+        });
+    }
 
-        expect(core.setFailed).toBeCalledWith('Invalid external secrets file: secrets section must be an array');
+    // Write out a new task definition file
+    var updatedTaskDefFile = tmp.fileSync({
+      tmpdir: process.env.RUNNER_TEMP,
+      prefix: 'task-definition-',
+      postfix: '.json',
+      keep: true,
+      discardDescriptor: true
     });
+    const newTaskDefContents = JSON.stringify(taskDefContents, null, 2);
+    fs.writeFileSync(updatedTaskDefFile.name, newTaskDefContents);
+    core.setOutput('task-definition', updatedTaskDefFile.name);
+  }
+  catch (error) {
+    core.setFailed(error.message);
+  }
+}
 
-    test('error returned for missing external secrets file', async () => {
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('correct-secrets-task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest')
-            .mockReturnValueOnce('missing-external-secrets-file.json')
-            .mockReturnValueOnce('us-east-2')
-            .mockReturnValueOnce(1234);
+module.exports = run;
 
-        await run();
-
-        expect(core.setFailed).toBeCalledWith('Secrets file does not exist: missing-external-secrets-file.json');
-    });
-});
+/* istanbul ignore next */
+if (require.main === module) {
+    run();
+}


### PR DESCRIPTION
*Issue #, if available:*

Attempting to solve #20 

*Description of changes:*

Disclaimer: I have barely used AWS as I'm a beginner, so I've got a some questions below... Anyways.

Added GitHub input for turning on handling parameter store and secretsmanager valueFrom. You can have a base set of secrets in the task definition (or only those) and an external JSON file for injecting secrets values without showing the AWS account ID (by using the output from configure AWS credential action).

~~But I'm wondering about the current implementation of "substituting the task definition with parameters/secrets"~~ (this is also my first time with node JS... so I haven't really gotten the hang of writing the tests with the mock JSON as my initial shot at it with jest failed spectacularly).

1. ~~Is the arn format even ok? I omitted the account ID and the parameter path expected must start with a "/". I'm pretty sure it's fine to not begin with a slash in parameter store, so if the parameter does not begin with a slash, should I instead insert a ":"?~~ Nevermind. Added the / at the beginning.
2. ~~Is it even bad if the arn is exposed in a public repository in the task definition? I'm just most concerned about an exposed account ID, if that's even dangerous to expose... I don't know, beginner, confused AWS person. Do you need the account ID? Some parts of the AWS docs have it, other parts don't (maybe I'm confusing regular parameters with public parameters for AMIs?).~~ README now includes how to include the account ID.
3. ~~Not sure where the executionRoleArn is supposed to be.~~ Also not sure if I should update the JSON minimum role in the README.rst... mostly because I have NO clue what is actually needed... [I'm ~~struggling~~ successful with ECS deployment myself here...](https://github.com/Andrew-Chen-Wang/cookiecutter-django-ecs-github)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
