### PR TITLE
Include Environment Variables in Task Definitions with JSON Fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ input of the second:
 
 If containers in your task definition require different values depending on environment, you can specify a `merge` file that contains a JSON fragment to merge with the `task-definition`. `merge` task defintion JSON fragments can be used to modify any key/value pair in `task-definition`. If merging an array value, arrays from the `task-defition` and `merge` fragment will be concatenated.
 
+`containerDefintions` and `name` within each container definition are required.
+
 _task-def.json_
 
 ```json

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ input of the second:
         cluster: my-cluster
 ```
 
-If containers in your task definition require different values depending on environment, you can specify `merge` file that contains a JSON fragment to merge with the `task-definition`:
+If containers in your task definition require different values depending on environment, you can specify a `merge` file that contains a JSON fragment to merge with the `task-definition`. `merge` task defintion JSON fragments can be used to modify any key/value pair in `task-definition`. If merging an array value, arrays from the `task-defition` and `merge` fragment will be concatenated.
 
 _task-def.json_
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: true
   image:
     description: 'The URI of the container image to insert into the ECS task definition'
-    required: true
+    required: false
   merge:
     description: 'The path to a task definition JSON fragment file to merge with the task defintion'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   image:
     description: 'The URI of the container image to insert into the ECS task definition'
     required: true
+  merge:
+    description: 'The path to a task definition JSON fragment file to merge with the task defintion'
+    required: false
 outputs:
   task-definition:
     description: 'The path to the rendered task definition file'

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ async function run() {
     // Get inputs
     const taskDefinitionFile = core.getInput('task-definition', { required: true });
     const containerName = core.getInput('container-name', { required: true });
-    const imageURI = core.getInput('image', { required: true });
+    const imageURI = core.getInput('image', { required: false });
     const mergeFile = core.getInput('merge', { required: false });
 
     // Parse the task definition
@@ -32,7 +32,7 @@ async function run() {
     }
     const taskDefContents = require(taskDefPath);
 
-    // Insert the image URI
+    // Get containerDef with name `containerName`
     if (!Array.isArray(taskDefContents.containerDefinitions)) {
       throw new Error('Invalid task definition format: containerDefinitions section is not present or is not an array');
     }
@@ -42,7 +42,12 @@ async function run() {
     if (!containerDef) {
       throw new Error('Invalid task definition: Could not find container definition with matching name');
     }
-    containerDef.image = imageURI;
+
+    // Check for imageURI
+    if(imageURI) {
+      // Insert the image URI
+      containerDef.image = imageURI;
+    }
 
     // Check for mergeFile
     if (mergeFile) {

--- a/index.test.js
+++ b/index.test.js
@@ -108,6 +108,124 @@ describe('Render task definition', () => {
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
     });
 
+    test('renders a task definition with a merge file', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('task-definition.json') // task-definition
+            .mockReturnValueOnce('web')                  // container-name
+            .mockReturnValueOnce('nginx:latest')         // image
+            .mockReturnValueOnce('merge.json');          // merge
+        
+        jest.mock('./merge.json', () => ({
+            containerDefinitions: [
+                {
+                    name: "web",
+                    environment: [
+                        {
+                            name: "log_level",
+                            value: "info"
+                        }
+                    ]
+                }
+            ]
+        }), {virtual: true});
+
+        await run();
+
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest",
+                        environment: [
+                            {
+                                name: "log_level",
+                                value: "info"
+                            }
+                        ]
+                    },
+                    {
+                        name: "sidecar",
+                        image: "hello"
+                    }
+                ]
+            }, null, 2)
+        );
+    });
+
+    test('renders a task definition with a merge file to merge an array value', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('task-definition.json')    // task-definition
+            .mockReturnValueOnce('web')                     // container-name
+            .mockReturnValueOnce('nginx:latest')            // image
+            .mockReturnValueOnce('merge-to-existing.json'); // merge
+        
+        jest.mock('./merge-to-existing.json', () => ({
+            containerDefinitions: [
+                {
+                    name: "web",
+                    environment: [
+                        {
+                            name: "env",
+                            value: "prod"
+                        }
+                    ]
+                }
+            ]
+        }), {virtual: true});
+
+        jest.mock('./task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image",
+                    environment: [
+                        {
+                            name: "log_level",
+                            value: "info"
+                        }
+                    ]
+                },
+                {
+                    name: "sidecar",
+                    image: "hello"
+                }
+            ]
+        }), { virtual: true });
+
+        await run();
+
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest",
+                        environment: [
+                            {
+                                name: "log_level",
+                                value: "info"
+                            },
+                            {
+                                name: "env",
+                                value: "prod"
+                            }
+                        ]
+                    },
+                    {
+                        name: "sidecar",
+                        image: "hello"
+                    }
+                ]
+            }, null, 2)
+        );
+    });
+
     test('error returned for missing task definition file', async () => {
         fs.existsSync.mockReturnValue(false);
         core.getInput = jest
@@ -172,5 +290,33 @@ describe('Render task definition', () => {
         await run();
 
         expect(core.setFailed).toBeCalledWith('Invalid task definition: Could not find container definition with matching name');
+    });
+
+    test('error returned for invalid merge file', async () => {
+        fs.existsSync.mockReturnValue(false);
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest')
+            .mockReturnValueOnce('invalid-merge-file.json');
+        
+        fs.existsSync.mockReturnValueOnce(JSON.stringify({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "nginx:latest"
+                },
+                {
+                    name: "sidecar",
+                    image: "hello"
+                }
+            ]
+        }));
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Merge file does not exist: invalid-merge-file.json');
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4546,6 +4546,11 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/aws-actions/amazon-ecs-render-task-definition#readme",
   "dependencies": {
     "@actions/core": "^1.2.6",
+    "lodash.mergewith": "^4.6.2",
     "tmp": "^0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
*Issue #:* https://github.com/aws-actions/amazon-ecs-render-task-definition/issues/20

*Description of changes:*

Merge a JSON fragment of a task definition with a task definition using [lodash's mergWith](https://lodash.com/docs/4.17.15#mergeWith). `containerDefinitions` and `name` within each container definition are required in the fragment.

- Merge JSON fragments specified with `merge` input with the task definition
- Added lodash mergeWith dependency
- Updated tests
- Updated README
- Updated `actions.yml` inputs (made image optional and added merge)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
