### PR TITLE
Simple way to add/change environment variables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   image:
     description: 'The URI of the container image to insert into the ECS task definition'
     required: true
+  environment-variables:
+    description: 'Variables to add to the container. In the form "NAME=value|FOO=bar"'
+    required: false
 outputs:
   task-definition:
     description: 'The path to the rendered task definition file'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1200,9 +1200,9 @@ async function run() {
       // Build an environment array with names and values
       var environment = [];
       // Get pairs by splitting with |
-      for (var pair in environmentVariables.split('|')) {
+      environmentVariables.split('|').forEach(function (item) {
         // Split pairs on =
-        pair = pair.split('=');
+        const pair = item.split('=');
         // If that pair didn't have exactly 2 parts (name and value)
         if (pair.length != 2) {
           throw new Error('Each environment-variable pair must be of form NAME=value');
@@ -1212,19 +1212,20 @@ async function run() {
           name: pair[0],
           value: pair[1],
         });
-      }
+      })
+
       // For each desired environment
-      for (const variable in environment) {
+      environment.forEach(function(item) {
         // Search container definition environment for one matching name
-        const variableDef = containerDef.environment.find((e) => e.name == variable.name);
+        const variableDef = containerDef.environment.find((e) => e.name == item.name);
         if (variableDef) {
           // If found, update
-          variableDef.value = variable.value;
+          variableDef.value = item.value;
         } else {
           // Else, create
-          containerDef.environment.push(variable);
+          containerDef.environment.push(item);
         }
-      }
+      })
     }
 
 

--- a/index.js
+++ b/index.js
@@ -44,9 +44,9 @@ async function run() {
       // Build an environment array with names and values
       var environment = [];
       // Get pairs by splitting with |
-      for (var pair in environmentVariables.split('|')) {
+      environmentVariables.split('|').forEach(function (item) {
         // Split pairs on =
-        pair = pair.split('=');
+        const pair = item.split('=');
         // If that pair didn't have exactly 2 parts (name and value)
         if (pair.length != 2) {
           throw new Error('Each environment-variable pair must be of form NAME=value');
@@ -56,19 +56,20 @@ async function run() {
           name: pair[0],
           value: pair[1],
         });
-      }
+      })
+
       // For each desired environment
-      for (const variable in environment) {
+      environment.forEach(function(item) {
         // Search container definition environment for one matching name
-        const variableDef = containerDef.environment.find((e) => e.name == variable.name);
+        const variableDef = containerDef.environment.find((e) => e.name == item.name);
         if (variableDef) {
           // If found, update
-          variableDef.value = variable.value;
+          variableDef.value = item.value;
         } else {
           // Else, create
-          containerDef.environment.push(variable);
+          containerDef.environment.push(item);
         }
-      }
+      })
     }
 
 

--- a/index.test.js
+++ b/index.test.js
@@ -75,12 +75,12 @@ describe('Render task definition', () => {
                                 value: "bar"
                             },
                             {
-                                name: "HELLO",
-                                value: "world"
-                            },
-                            {
                                 name: "DONT-TOUCH",
                                 value: "me"
+                            },
+                            {
+                                name: "HELLO",
+                                value: "world"
                             }
                         ]
                     },

--- a/index.test.js
+++ b/index.test.js
@@ -16,7 +16,8 @@ describe('Render task definition', () => {
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
             .mockReturnValueOnce('web')                  // container-name
-            .mockReturnValueOnce('nginx:latest');        // image
+            .mockReturnValueOnce('nginx:latest')         // image
+            .mockReturnValueOnce('FOO=bar|HELLO=world'); // environment-variables
 
         process.env = Object.assign(process.env, { GITHUB_WORKSPACE: __dirname });
         process.env = Object.assign(process.env, { RUNNER_TEMP: '/home/runner/work/_temp' });
@@ -32,7 +33,17 @@ describe('Render task definition', () => {
             containerDefinitions: [
                 {
                     name: "web",
-                    image: "some-other-image"
+                    image: "some-other-image",
+                    environment: [
+                        {
+                            name: "FOO",
+                            value: "not bar"
+                        },
+                        {
+                            name: "DONT-TOUCH",
+                            value: "me"
+                        }
+                    ]
                 },
                 {
                     name: "sidecar",
@@ -57,7 +68,21 @@ describe('Render task definition', () => {
                 containerDefinitions: [
                     {
                         name: "web",
-                        image: "nginx:latest"
+                        image: "nginx:latest",
+                        environment: [
+                            {
+                                name: "FOO",
+                                value: "bar"
+                            },
+                            {
+                                name: "HELLO",
+                                value: "world"
+                            },
+                            {
+                                name: "DONT-TOUCH",
+                                value: "me"
+                            }
+                        ]
                     },
                     {
                         name: "sidecar",
@@ -69,12 +94,13 @@ describe('Render task definition', () => {
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
     });
 
-    test('renders a task definition at an absolute path', async () => {
+    test('renders a task definition at an absolute path, and with initial environment empty', async () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('/hello/task-definition.json') // task-definition
             .mockReturnValueOnce('web')                  // container-name
-            .mockReturnValueOnce('nginx:latest');        // image
+            .mockReturnValueOnce('nginx:latest')         // image
+            .mockReturnValueOnce('EXAMPLE=here');        // environment-variables
         jest.mock('/hello/task-definition.json', () => ({
             family: 'task-def-family',
             containerDefinitions: [
@@ -100,7 +126,13 @@ describe('Render task definition', () => {
                 containerDefinitions: [
                     {
                         name: "web",
-                        image: "nginx:latest"
+                        image: "nginx:latest",
+                        environment: [
+                            {
+                                name: "EXAMPLE",
+                                value: "here"
+                            }
+                        ]
                     }
                 ]
             }, null, 2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-actions-amazon-ecs-render-task-definition",
-  "version": "1.0.22",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-actions-amazon-ecs-render-task-definition",
-  "version": "1.0.22",
+  "version": "1.1.0",
   "description": "Render Amazon ECS task definition file",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
*Issue #, if available:* #112

*Description of changes:* These commits add a `environment-variables` input. It accepts `KEY=value` environment variables, separated by `|`.

For example: `VARIABLE_NAME=value|ANOTHER_ONE=foo|YET_ANOTHER=bar`.

Those are added to the rendered task definition: if the `environment` array does not exist, it is created. if the specified `KEY` name is present it is updated, if not, created as well.

I've updated the tests to include testing for all these cases (creating array, update existing, create new, not changing one that is present, etc), all is missing currently is a test case for the new throw (when the input has an invalid format).

Here's an usage example, to update the container environment variable with the currently deployed tag (which, in my use case, allows the web service to get its own running version at runtime):
```yml
name: Deploy

on:
  workflow_dispatch:
    inputs:
      version:
        description: 'Version to deploy'
        required: true

jobs:
  deploy:
    runs-on: ubuntu-latest
    steps:
    - name: Checkout
      uses: actions/checkout@v2

    - name: Configure AWS credentials
      uses: aws-actions/configure-aws-credentials@v1
      with:
        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
        aws-region: us-east-1

    - name: Fill in the new image ID in the Amazon ECS task definition
      id: task-def
      uses: Misterio77/amazon-ecs-render-task-definition@v1
      with:
        task-definition: ecs_task.json
        container-name: backend
        image: 123456789012.dkr.ecr.us-east-1.amazonaws.com/backend:${{ github.event.inputs.version }}
        environment-variables: BACKEND_VERSION=${{ github.event.inputs.version }}

    - name: Deploy Amazon ECS task definition
      uses: aws-actions/amazon-ecs-deploy-task-definition@v1.1.0-pre3
      with:
        task-definition: ${{ steps.task-def.outputs.task-definition }}
        service: backend
        cluster: backend
```

Following semver, i've bumped the version on `package.json` to `1.1.0`, as a new feature was added in a backward-compatible way.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
