### PR TITLE
Add ability to specify container definition command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   image:
     description: 'The URI of the container image to insert into the ECS task definition'
     required: true
+  command:
+    description: 'The command used by ECS to start the container image'
+    required: false
   environment-variables:
     description: 'Variables to add to the container. Each variable is of the form KEY=value, you can specify multiple variables with multi-line YAML strings.'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -1194,6 +1194,7 @@ async function run() {
     const imageURI = core.getInput('image', { required: true });
 
     const environmentVariables = core.getInput('environment-variables', { required: false });
+    const command = core.getInput('command', { required: false });
 
     // Parse the task definition
     const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
@@ -1216,6 +1217,10 @@ async function run() {
     }
     containerDef.image = imageURI;
 
+    if (command) {
+      containerDef.command = command.split(' ')
+    }
+    
     if (environmentVariables) {
 
       // If environment array is missing, create it

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ async function run() {
     const imageURI = core.getInput('image', { required: true });
 
     const environmentVariables = core.getInput('environment-variables', { required: false });
+    const command = core.getInput('command', { required: false });
 
     // Parse the task definition
     const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
@@ -33,6 +34,14 @@ async function run() {
     }
     containerDef.image = imageURI;
 
+    if (command) {
+      if (!Array.isArray(command)) {
+        throw new Error(`Cannot parse the command. The command must be a list of strings composing the docker command.`);
+      }
+      
+      containerDef.command = command;
+    }
+    
     if (environmentVariables) {
 
       // If environment array is missing, create it

--- a/index.js
+++ b/index.js
@@ -35,11 +35,7 @@ async function run() {
     containerDef.image = imageURI;
 
     if (command) {
-      if (!Array.isArray(command)) {
-        throw new Error(`Cannot parse the command. The command must be a list of strings composing the docker command.`);
-      }
-      
-      containerDef.command = command;
+      containerDef.command = command.split(' ')
     }
     
     if (environmentVariables) {


### PR DESCRIPTION
*Description of changes:*

This adds support for rendering the command used to start the container in the task definition.

Some context. I have multiple ecs services depending on the same image, but with different startup commands. This allows to build the docker image once and then render the task definitions and deploy them with different commands.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
