### PR TITLE
chore: Add semantic PR check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,3 +14,19 @@ jobs:
       run: |
         npm ci
         npm test
+
+  conventional-commits:
+    name: Semantic Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: validate
+        uses: actions/github-script@v6
+        with:
+          script: |
+            // See https://gist.github.com/marcojahn/482410b728c31b221b70ea6d2c433f0c#file-conventional-commit-regex-md
+            const regex = /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*)/g;
+            const pr = context.payload.pull_request;
+            const title = pr.title;
+            if (title.match(regex) == null) {
+              throw `PR title "${title}"" does not match conventional commits from https://www.conventionalcommits.org/en/v1.0.0/`
+            }


### PR DESCRIPTION
I noticed that Mergify is not running against any PRs, because the Semantic Pull Request check is not running.  This change copies the one from https://github.com/aws-actions/amazon-ecs-deploy-task-definition over to this repo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
