### PR TITLE
feat: add possibility to add more than one container in container-name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: 'The path to the ECS task definition JSON file'
     required: true
   container-name:
-    description: 'The name of the container defined in the containerDefinitions section of the ECS task definition'
+    description: 'The name of the container or containers defined in the containerDefinitions section of the ECS task definition. If more than one container, add the names comma separated.'
     required: true
   image:
     description: 'The URI of the container image to insert into the ECS task definition'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1406,17 +1406,26 @@ async function run() {
     }
     const taskDefContents = require(taskDefPath);
 
-    // Insert the image URI
-    if (!Array.isArray(taskDefContents.containerDefinitions)) {
-      throw new Error('Invalid task definition format: containerDefinitions section is not present or is not an array');
+    const containersNames = containerName.split(',');
+    // Check if containerNames length is major than 1
+    // Regex to check if a string is comma separated
+    const pattern = /^([^,]+,)*[^,]+$/g;
+    if (!containerName.match(pattern)) {
+      throw new Error('Invalid format for container name. Please use a single value or comma separated values');
     }
-    const containerDef = taskDefContents.containerDefinitions.find(function(element) {
-      return element.name == containerName;
-    });
-    if (!containerDef) {
-      throw new Error('Invalid task definition: Could not find container definition with matching name');
-    }
-    containerDef.image = imageURI;
+
+    containersNames.forEach(contName => {
+      // Insert the image URI
+      if (!Array.isArray(taskDefContents.containerDefinitions)) {
+        throw new Error('Invalid task definition format: containerDefinitions section is not present or is not an array');
+      }
+      const containerDef = taskDefContents.containerDefinitions.find(function(element) {
+        return element.name == contName;
+      });
+      if (!containerDef) {
+        throw new Error('Invalid task definition: Could not find container definition with matching name');
+      }
+      containerDef.image = imageURI;      
 
     if (environmentVariables) {
 
@@ -1454,7 +1463,7 @@ async function run() {
         }
       })
     }
-
+  });
 
     // Write out a new task definition file
     var updatedTaskDefFile = tmp.fileSync({

--- a/index.js
+++ b/index.js
@@ -21,17 +21,26 @@ async function run() {
     }
     const taskDefContents = require(taskDefPath);
 
-    // Insert the image URI
-    if (!Array.isArray(taskDefContents.containerDefinitions)) {
-      throw new Error('Invalid task definition format: containerDefinitions section is not present or is not an array');
+    const containersNames = containerName.split(',');
+    // Check if containerNames length is major than 1
+    // Regex to check if a string is comma separated
+    const pattern = /^([^,]+,)*[^,]+$/g;
+    if (!containerName.match(pattern)) {
+      throw new Error('Invalid format for container name. Please use a single value or comma separated values');
     }
-    const containerDef = taskDefContents.containerDefinitions.find(function(element) {
-      return element.name == containerName;
-    });
-    if (!containerDef) {
-      throw new Error('Invalid task definition: Could not find container definition with matching name');
-    }
-    containerDef.image = imageURI;
+
+    containersNames.forEach(contName => {
+      // Insert the image URI
+      if (!Array.isArray(taskDefContents.containerDefinitions)) {
+        throw new Error('Invalid task definition format: containerDefinitions section is not present or is not an array');
+      }
+      const containerDef = taskDefContents.containerDefinitions.find(function(element) {
+        return element.name == contName;
+      });
+      if (!containerDef) {
+        throw new Error('Invalid task definition: Could not find container definition with matching name');
+      }
+      containerDef.image = imageURI;      
 
     if (environmentVariables) {
 
@@ -69,7 +78,7 @@ async function run() {
         }
       })
     }
-
+  });
 
     // Write out a new task definition file
     var updatedTaskDefFile = tmp.fileSync({

--- a/index.test.js
+++ b/index.test.js
@@ -150,6 +150,18 @@ describe('Render task definition', () => {
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
     });
 
+    test('error returned if container-name input is not well formated', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('/hello/task-definition.json')
+            .mockReturnValueOnce('web,')
+            .mockReturnValueOnce('nginx:latest');
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid format for container name. Please use a single value or comma separated values');
+    });
+
     test('error returned for missing task definition file', async () => {
         fs.existsSync.mockReturnValue(false);
         core.getInput = jest


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-actions/amazon-ecs-render-task-definition/issues/228

*Description of changes:*

In this PR I'm adding the possibilty to pass more than one container inside container-name input. The container names can be passed comma separated. The same image and environment variables will be applied to all the containers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
