### PR TITLE
adds env-files input to the github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   environment-variables:
     description: 'Variables to add to the container. Each variable is of the form KEY=value, you can specify multiple variables with multi-line YAML strings.'
     required: false
+  env-files:
+    description: 'S3 object arns to set env variables onto the container. You can specify multiple files with multi-line YAML strings.'
+    required: false
 outputs:
   task-definition:
     description: 'The path to the rendered task definition file'

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ async function run() {
     const imageURI = core.getInput('image', { required: true });
 
     const environmentVariables = core.getInput('environment-variables', { required: false });
-
+    const envFiles = core.getInput('env-files', { required: false });
     // Parse the task definition
     const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
       taskDefinitionFile :
@@ -33,13 +33,27 @@ async function run() {
     }
     containerDef.image = imageURI;
 
-    if (environmentVariables) {
+    if (envFiles) {
+      containerDef.environmentFiles = [];
+        envFiles.split('\n').forEach(function (line) {
+          // Trim whitespace
+          const trimmedLine = line.trim();
+          // Skip if empty
+          if (trimmedLine.length === 0) { return; }
+          // Build object
+          const variable = {
+            value: trimmedLine,
+            type: "s3",
+          };
+          containerDef.environmentFiles.push(variable);
+        })
+    }
 
+    if (environmentVariables) {
       // If environment array is missing, create it
       if (!Array.isArray(containerDef.environment)) {
         containerDef.environment = [];
       }
-
       // Get pairs by splitting on newlines
       environmentVariables.split('\n').forEach(function (line) {
         // Trim whitespace

--- a/index.test.js
+++ b/index.test.js
@@ -27,7 +27,8 @@ describe('Render task definition', () => {
             .mockReturnValueOnce('task-definition.json') // task-definition
             .mockReturnValueOnce('web')                  // container-name
             .mockReturnValueOnce('nginx:latest')         // image
-            .mockReturnValueOnce('FOO=bar\nHELLO=world'); // environment-variables
+            .mockReturnValueOnce('FOO=bar\nHELLO=world') // environment-variables
+            .mockReturnValueOnce('arn:aws:s3:::s3_bucket_name/envfile_object_name.env'); // env-files
 
         process.env = Object.assign(process.env, { GITHUB_WORKSPACE: __dirname });
         process.env = Object.assign(process.env, { RUNNER_TEMP: '/home/runner/work/_temp' });
@@ -52,6 +53,12 @@ describe('Render task definition', () => {
                         {
                             name: "DONT-TOUCH",
                             value: "me"
+                        }
+                    ],
+                    environmentFiles: [
+                        {
+                            value: "arn:aws:s3:::s3_bucket_name/envfile_object_name.env",
+                            type: "s3"
                         }
                     ]
                 },
@@ -91,6 +98,12 @@ describe('Render task definition', () => {
                             {
                                 name: "HELLO",
                                 value: "world"
+                            }
+                        ],
+                        environmentFiles: [
+                            {
+                                value: "arn:aws:s3:::s3_bucket_name/envfile_object_name.env",
+                                type: "s3"
                             }
                         ]
                     },


### PR DESCRIPTION
*Description of changes:*

Adds the `env-files` input to the github action to be possible to pass env files into the task definition  as described here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/taskdef-envfiles.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
