### PR TITLE
chore(ci): Upgrade workflows to non-deprecated runtimes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Run tests
       run: |
         npm ci

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: master
     - name: Package


### PR DESCRIPTION
Hi! 👋🏻

Several of the Github Actions in the repo are using the deprecated Node.js 12 runtime. Github have announced that everyone should move away from the deprecated Node.js runtime as of [this](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) blogpost.

*Description of changes:*
I've upgraded the deprecated actions to versions that uses non-deprecated runtimes.

Open to feedback if there are any other changes wanted done regarding Github Actions 😄

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.