### PR TITLE
feat: ability to configure log driver and log options

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,25 @@ input of the second:
         cluster: my-cluster
 ```
 
+Use the following approach to configure your log driver if needed:
+
+```yaml
+    - name: Render Amazon ECS task definition
+      id: render-web-container
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition.json
+        container-name: web
+        image: amazon/amazon-ecs-sample:latest
+        log-configuration-log-driver: awslogs
+        log-configuration-log-options: |
+          awslogs-create-group=true
+          awslogs-group=/ecs/web
+          awslogs-region=us-east-1
+          awslogs-stream-prefix=ecs
+
+```
+
 See [action.yml](action.yml) for the full documentation for this action's inputs and outputs.
 
 ## License Summary

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,12 @@ inputs:
   environment-variables:
     description: 'Variables to add to the container. Each variable is of the form KEY=value, you can specify multiple variables with multi-line YAML strings.'
     required: false
+  log-configuration-log-driver:
+    description: "Create/Override logDriver inside logConfiguration"
+    required: false
+  log-configuration-options:
+    description: "Create/Override options inside logConfiguration. Each variable is of the form key=value, you can specify multiple variables with multi-line YAML strings."
+    required: false
 outputs:
   task-definition:
     description: 'The path to the rendered task definition file'

--- a/index.js
+++ b/index.js
@@ -75,9 +75,9 @@ async function run() {
 
     if (logConfigurationLogDriver) {
       if (!containerDef.logConfiguration) { containerDef.logConfiguration = {} }
-      const validDrivers = ["json-file", "syslog", "journald", "gelf", "fluentd", "awslogs", "splunk", "awsfirelens"];
+      const validDrivers = ["json-file", "syslog", "journald", "logentries", "gelf", "fluentd", "awslogs", "splunk", "awsfirelens"];
       if (!validDrivers.find(driver => driver === logConfigurationLogDriver)) {
-        throw new Error(`'${logConfigurationLogDriver}' is invalid logConfigurationLogDriver. valid options are ${validDrivers}. More details: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html`)
+        throw new Error(`'${logConfigurationLogDriver}' is invalid logConfigurationLogDriver`)
       }
       containerDef.logConfiguration.logDriver = logConfigurationLogDriver
     }

--- a/index.js
+++ b/index.js
@@ -76,8 +76,8 @@ async function run() {
     if (logConfigurationLogDriver) {
       if (!containerDef.logConfiguration) { containerDef.logConfiguration = {} }
       const validDrivers = ["json-file", "syslog", "journald", "logentries", "gelf", "fluentd", "awslogs", "splunk", "awsfirelens"];
-      if (!validDrivers.find(driver => driver === logConfigurationLogDriver)) {
-        throw new Error(`'${logConfigurationLogDriver}' is invalid logConfigurationLogDriver`)
+      if (!validDrivers.includes(logConfigurationLogDriver)) {
+        throw new Error(`'${logConfigurationLogDriver}' is invalid logConfigurationLogDriver. valid options are ${validDrivers}. More details: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html`)
       }
       containerDef.logConfiguration.logDriver = logConfigurationLogDriver
     }

--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ async function run() {
 
     const environmentVariables = core.getInput('environment-variables', { required: false });
 
+    const logConfigurationLogDriver = core.getInput("log-configuration-log-driver", { required: false });
+    const logConfigurationOptions = core.getInput("log-configuration-options", { required: false });
+
     // Parse the task definition
     const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
       taskDefinitionFile :
@@ -25,7 +28,7 @@ async function run() {
     if (!Array.isArray(taskDefContents.containerDefinitions)) {
       throw new Error('Invalid task definition format: containerDefinitions section is not present or is not an array');
     }
-    const containerDef = taskDefContents.containerDefinitions.find(function(element) {
+    const containerDef = taskDefContents.containerDefinitions.find(function (element) {
       return element.name == containerName;
     });
     if (!containerDef) {
@@ -50,7 +53,7 @@ async function run() {
         const separatorIdx = trimmedLine.indexOf("=");
         // If there's nowhere to split
         if (separatorIdx === -1) {
-            throw new Error(`Cannot parse the environment variable '${trimmedLine}'. Environment variable pairs must be of the form NAME=value.`);
+          throw new Error(`Cannot parse the environment variable '${trimmedLine}'. Environment variable pairs must be of the form NAME=value.`);
         }
         // Build object
         const variable = {
@@ -70,6 +73,29 @@ async function run() {
       })
     }
 
+    if (logConfigurationLogDriver) {
+      if (!containerDef.logConfiguration) { containerDef.logConfiguration = {} }
+      const validDrivers = ["json-file", "syslog", "journald", "gelf", "fluentd", "awslogs", "splunk", "awsfirelens"];
+      if (!validDrivers.find(driver => driver === logConfigurationLogDriver)) {
+        throw new Error(`'${logConfigurationLogDriver}' is invalid logConfigurationLogDriver. valid options are ${validDrivers}. More details: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html`)
+      }
+      containerDef.logConfiguration.logDriver = logConfigurationLogDriver
+    }
+
+    if (logConfigurationOptions) {
+      if (!containerDef.logConfiguration) { containerDef.logConfiguration = {} }
+      if (!containerDef.logConfiguration.options) { containerDef.logConfiguration.options = {} }
+      logConfigurationOptions.split("\n").forEach(function (option) {
+        option = option.trim();
+        if (option && option.length) { // not a blank line
+          if (option.indexOf("=") == -1) {
+            throw new Error(`Can't parse logConfiguration option ${option}. Must be in key=value format, one per line`);
+          }
+          const [key, value] = option.split("=");
+          containerDef.logConfiguration.options[key] = value
+        }
+      })
+    }
 
     // Write out a new task definition file
     var updatedTaskDefFile = tmp.fileSync({
@@ -92,5 +118,5 @@ module.exports = run;
 
 /* istanbul ignore next */
 if (require.main === module) {
-    run();
+  run();
 }

--- a/index.test.js
+++ b/index.test.js
@@ -71,7 +71,7 @@ describe('Render task definition', () => {
             postfix: '.json',
             keep: true,
             discardDescriptor: true
-          });
+        });
         expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
             JSON.stringify({
                 family: 'task-def-family',
@@ -129,7 +129,7 @@ describe('Render task definition', () => {
             postfix: '.json',
             keep: true,
             discardDescriptor: true
-          });
+        });
         expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
             JSON.stringify({
                 family: 'task-def-family',
@@ -148,6 +148,67 @@ describe('Render task definition', () => {
             }, null, 2)
         );
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
+    });
+
+    test('renders logConfiguration on the task definition', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest')
+            .mockReturnValueOnce('FOO=bar\nHELLO=world')
+            .mockReturnValueOnce('awslogs')
+            .mockReturnValueOnce(`awslogs-create-group=true\nawslogs-group=/ecs/web\nawslogs-region=us-east-1\nawslogs-stream-prefix=ecs`);
+
+        await run()
+
+        expect(tmp.fileSync).toHaveBeenNthCalledWith(1, {
+            tmpdir: '/home/runner/work/_temp',
+            prefix: 'task-definition-',
+            postfix: '.json',
+            keep: true,
+            discardDescriptor: true
+        });
+
+
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest",
+                        environment: [
+                            {
+                                name: "FOO",
+                                value: "bar"
+                            },
+                            {
+                                name: "DONT-TOUCH",
+                                value: "me"
+                            },
+                            {
+                                name: "HELLO",
+                                value: "world"
+                            }
+                        ],
+                        logConfiguration: {
+                            logDriver: "awslogs",
+                            options: {
+                                "awslogs-create-group": "true",
+                                "awslogs-group": "/ecs/web",
+                                "awslogs-region": "us-east-1",
+                                "awslogs-stream-prefix": "ecs"
+                            }
+                        }
+                    },
+                    {
+                        name: "sidecar",
+                        image: "hello"
+                    }
+                ]
+            }, null, 2)
+        );
     });
 
     test('error returned for missing task definition file', async () => {


### PR DESCRIPTION
*Issue #254*

*Description of changes:*

For my workflow i need to override the `awslogs-group` value so it doesn't clash with other group names. app on dev environment and app on staging would override messages if the task definition file is shared between them, and turns out it is.

By having a chance to override log configuration i can rename the property without having to keep different versions of the same task definiton.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
