### PR TITLE
fix: update ncc and minor workflow enhancements

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,18 +6,23 @@ name: Check
 jobs:
   check:
     name: Run Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      #Version actions/checkout@V3.6.0
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+    - name: Node setup
+      #Version actions/setup-node@v3.8.1
+      uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
+      with:
+        node-version: "18.16.1"
     - name: Run tests
       run: |
         npm ci
         npm test
-
   conventional-commits:
     name: Semantic Pull Request
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: validate
         uses: actions/github-script@v6

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,12 +8,18 @@ name: Package
 jobs:
   check:
     name: Package distribution file
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      #Version actions/checkout@V3.6.0
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       with:
         ref: master
+    - name: Node setup
+      #Version actions/setup-node@v3.8.1
+      uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
+      with:
+        node-version: "18.16.1"
     - name: Package
       run: |
         npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "tmp": "^0.2.1"
       },
       "devDependencies": {
-        "@zeit/ncc": "^0.22.3",
+        "@vercel/ncc": "^0.38.0",
         "eslint": "^8.50.0",
         "jest": "^29.7.0"
       }
@@ -1291,11 +1291,10 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
-    "node_modules/@zeit/ncc": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.22.3.tgz",
-      "integrity": "sha512-jnCLpLXWuw/PAiJiVbLjA8WBC0IJQbFeUwF4I9M+23MvIxTxk5pD4Q8byQBSPmHQjz5aBoA7AKAElQxMpjrCLQ==",
-      "deprecated": "@zeit/ncc is no longer maintained. Please use @vercel/ncc instead.",
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.0.tgz",
+      "integrity": "sha512-B4YKZMm/EqMptKSFyAq4q2SlgJe+VCmEH6Y8gf/E1pTlWbsUJpuH1ymik2Ex3aYO5mCWwV1kaSYHSQOT8+4vHA==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -5453,10 +5452,10 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
-    "@zeit/ncc": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.22.3.tgz",
-      "integrity": "sha512-jnCLpLXWuw/PAiJiVbLjA8WBC0IJQbFeUwF4I9M+23MvIxTxk5pD4Q8byQBSPmHQjz5aBoA7AKAElQxMpjrCLQ==",
+    "@vercel/ncc": {
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.0.tgz",
+      "integrity": "sha512-B4YKZMm/EqMptKSFyAq4q2SlgJe+VCmEH6Y8gf/E1pTlWbsUJpuH1ymik2Ex3aYO5mCWwV1kaSYHSQOT8+4vHA==",
       "dev": true
     },
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "tmp": "^0.2.1"
   },
   "devDependencies": {
-    "@zeit/ncc": "^0.38.0",
+    "@vercel/ncc": "^0.38.0",
     "eslint": "^8.50.0",
     "jest": "^29.7.0"
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "tmp": "^0.2.1"
   },
   "devDependencies": {
-    "@zeit/ncc": "^0.22.3",
+    "@zeit/ncc": "^0.38.0",
     "eslint": "^8.50.0",
     "jest": "^29.7.0"
   }


### PR DESCRIPTION
*Issue #268 

*Description of changes:*
- updated to use vercel/ncc as zeit/ncc is not maintained. this also resolved the openssl error in package workflow (npm run package)
- Added nojes18 setup to the workflow as a best practice.
- updated checkout action to use v3 - resolved workflow warning of action using nodejs 12.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
