### PR TITLE
fix: Node.js 16 actions are deprecated

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,13 +9,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      #Version actions/checkout@V3.6.0
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      uses: actions/checkout@v4
     - name: Node setup
-      #Version actions/setup-node@v3.8.1
-      uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
+      uses: actions/setup-node@v4
       with:
-        node-version: "18.16.1"
+        node-version: 20
     - name: Run tests
       run: |
         npm ci

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,15 +11,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      #Version actions/checkout@V3.6.0
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      uses: actions/checkout@v4
       with:
         ref: master
     - name: Node setup
-      #Version actions/setup-node@v3.8.1
-      uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
+      uses: actions/setup-node@v4
       with:
-        node-version: "18.16.1"
+        node-version: 20
     - name: Package
       run: |
         npm ci

--- a/action.yml
+++ b/action.yml
@@ -29,5 +29,5 @@ outputs:
   task-definition:
     description: 'The path to the rendered task definition file'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bump node from 16 to 20 to fix Github Actions warnings:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: aws-actions/amazon-ecs-render-task-definition@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
