### PR TITLE
feat: check command input is valid array

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,18 @@ async function run() {
     containerDef.image = imageURI;
 
     if (command) {
-      containerDef.command = command.split(' ')
+      const invalidCommandErrorMessage = `Invalid command: '${command}'. command must be a valid JSON array.`
+      try {
+        const parsedCommand = JSON.parse(command);
+        if (!Array.isArray(parsedCommand)) {
+          // The parsed object is not an array.
+          throw new Error(invalidCommandErrorMessage);
+        } 
+        containerDef.command = parsedCommand;
+      } catch (e) {
+        // The string is not a valid array.
+        throw new Error(invalidCommandErrorMessage);
+      }
     }
 
     if (environmentVariables) {

--- a/index.test.js
+++ b/index.test.js
@@ -386,7 +386,7 @@ describe('Render task definition', () => {
             .mockReturnValueOnce('awslogs')
             .mockReturnValueOnce('awslogs-create-group=true\nawslogs-group=/ecs/web\nawslogs-region=us-east-1\nawslogs-stream-prefix=ecs')
             .mockReturnValueOnce('key1=value1\nkey2=value2')
-            .mockReturnValueOnce('npm start --nice --please');
+            .mockReturnValueOnce('["npm", "start", "--nice", "--please"]');
 
         await run();
 
@@ -445,5 +445,22 @@ describe('Render task definition', () => {
                 ]
             }, null, 2)
         );
+    });
+
+    test('error returned for invalid command', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('task-definition.json')
+            .mockReturnValueOnce('web')
+            .mockReturnValueOnce('nginx:latest')
+            .mockReturnValueOnce('EXAMPLE=here')
+            .mockReturnValueOnce('awslogs')
+            .mockReturnValueOnce('awslogs-create-group=true\nawslogs-group=/ecs/web\nawslogs-region=us-east-1\nawslogs-stream-prefix=ecs')
+            .mockReturnValueOnce('key1=value1\nkey2=value2')
+            .mockReturnValueOnce('npm start --nice --please');
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid command: \'npm start --nice --please\'. command must be a valid JSON array.');
     });
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Commands that include spaces within arguments, special characters, or need quoting can break if naively split on whitespace(`command.split(' ')`) . 

Take for example this input:
`alembic revision --autogenerate -m "Your message here"`. 

Splitting on whitespace will result in container def receving the command 
`[ "alembic", "revision",  "--autogenerate", " -m", "Your",  "message", " here"]` which is incorrect and will result in an error when the command is run.

This PR solves this by validating that the command input is a valid array and adding it to the container definition. Otherwise an error is thrown.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
