### PR TITLE
Add new integration tests for options to fetch task definition

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -58,6 +58,8 @@ jobs:
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
+    #validation 
+
     - name: Validate Amazon ECS task definition file 
       env:
         TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
@@ -83,6 +85,8 @@ jobs:
       run: |
         diff expected-task-definition-family $TASK_DEF_FAM
         diff expected-task-definition-family $TASK_DEF_REV
+
+    #registration
 
     - name: Register Amazon ECS task definition with task definition file 
       env:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -68,20 +68,20 @@ jobs:
 
     - name: Validate Amazon ECS task definition arn 
       env:
-        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition-arn }}
+        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition }}
       run: |
         diff expected-task-definition.json $TASK_DEF_ARN
 
     - name: Validate Amazon ECS task definition with family 
       env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
+        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition }}
       run: |
         diff expected-task-definition.json $TASK_DEF_FAM
     
     - name: Validate Amazon ECS task definition with family and revision
       env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
-        TASK_DEF_REV: ${{ steps.render-task-definition-revision.outputs.task-definition-revision }}
+        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition }}
+        TASK_DEF_REV: ${{ steps.render-task-definition-revision.outputs.task-definition }}
       run: |
         diff expected-task-definition.json $TASK_DEF_FAM
         diff expected-task-definition.json $TASK_DEF_REV

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -37,7 +37,7 @@ jobs:
       id: render-task-definition-arn
       uses: shesaave/amazon-ecs-render-task-definition@8a6aa737d95c816e467f33352a951067707a09ab
       with:
-        task-definition-arn: task-definition-arn
+        task-definition-arn: arn:aws:ecs:us-west-2:851725652419:task-definition/fetch-def-task-definition:16
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -70,6 +70,6 @@ jobs:
       uses: aws-actions/amazon-ecs-deploy-task-definition@abe77ebded86b685c231c58bd5936280c6fcc011
       with:
         task-definition: task-definition.json
-        service: github-actions-deploy-task-def-integ-test
-        cluster: github-actions-deploy-task-def-integ-test
+        service: fetch-def-service
+        cluster: fetch-def-cluster
         wait-for-service-stability: true

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -38,7 +38,7 @@ jobs:
       uses: shesaave/amazon-ecs-render-task-definition@8a6aa737d95c816e467f33352a951067707a09ab
       with:
         task-definition-arn: arn:aws:ecs:us-west-2:851725652419:task-definition/fetch-def-task-definition:16
-        container-name: sample-app
+        container-name: fetch-app
         image: amazon/amazon-ecs-sample:latest
 
     - name: Render Amazon ECS task definition with task definition family 

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -25,7 +25,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
-    - name: Render Amazon ECS task definition
+    - name: Render Amazon ECS task definition with task definition file 
       id: render-task-definition
       uses: aws-actions/amazon-ecs-render-task-definition@964c59d79b99c32ccbda305c9e6afb0cec542076
       with:
@@ -33,14 +33,79 @@ jobs:
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
-    - name: Validate Amazon ECS task definition
+    - name: Render Amazon ECS task definition with task definition arn (amazon resource name)
+      id: render-task-definition
+      uses: aws-actions/amazon-ecs-render-task-definition@964c59d79b99c32ccbda305c9e6afb0cec542076
+      with:
+        task-definition-arn: task-definition-arn
+        container-name: sample-app
+        image: amazon/amazon-ecs-sample:latest
+
+    - name: Render Amazon ECS task definition with task definition family 
+      id: render-task-definition
+      uses: aws-actions/amazon-ecs-render-task-definition@964c59d79b99c32ccbda305c9e6afb0cec542076
+      with:
+        task-definition-family: task-definition-family
+        container-name: sample-app
+        image: amazon/amazon-ecs-sample:latest
+
+    - name: Render Amazon ECS task definition with task definition family and revision
+      id: render-task-definition
+      uses: aws-actions/amazon-ecs-render-task-definition@964c59d79b99c32ccbda305c9e6afb0cec542076
+      with:
+        task-definition-famiy: task-definition-family
+        task-definition-revision: task-definition-revision
+        container-name: sample-app
+        image: amazon/amazon-ecs-sample:latest
+
+    - name: Validate Amazon ECS task definition file 
       env:
         TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
       run: |
         diff expected-task-definition.json $TASK_DEF_FILE
 
-    - name: Register Amazon ECS task definition
+    - name: Validate Amazon ECS task definition arn 
+      env:
+        TASK_DEF_ARN: ${{ steps.render-task-definition.outputs.task-definition-arn }}
+      run: |
+        diff expected-task-definition-arn $TASK_DEF_ARN
+
+    - name: Validate Amazon ECS task definition with family 
+      env:
+        TASK_DEF_FAM: ${{ steps.render-task-definition.outputs.task-definition-family }}
+      run: |
+        diff expected-task-definition-family $TASK_DEF_FAM
+    
+    - name: Validate Amazon ECS task definition with family and revision
+      env:
+        TASK_DEF_FAM: ${{ steps.render-task-definition.outputs.task-definition-family }}
+        TASK_DEF_REV: ${{ steps.render-task-definition.outputs.task-definition-revision }}
+      run: |
+        diff expected-task-definition-family $TASK_DEF_FAM
+        diff expected-task-definition-family $TASK_DEF_REV
+
+    - name: Register Amazon ECS task definition with task definition file 
       env:
         TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FILE
+
+    - name: Register Amazon ECS task definition with task definition arn 
+      env:
+        TASK_DEF_ARN: ${{ steps.render-task-definition.outputs.task-definition-arn }}
+      run: |
+        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_ARN
+
+    - name: Register Amazon ECS task definition with task definition family 
+      env:
+        TASK_DEF_FAM: ${{ steps.render-task-definition.outputs.task-definition-family }}
+      run: |
+        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
+
+    - name: Register Amazon ECS task definition with task definition family and revision 
+      env:
+        TASK_DEF_FAM : ${{ steps.render-task-definition.outputs.task-definition-family }}
+        TASK_DEF_REV : ${{ steps.render-task-definition.outputs.task-definition-revision }}
+      run: |
+        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
+        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_REV

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -70,26 +70,26 @@ jobs:
 
     - name: Register Amazon ECS task definition with task definition file 
       env:
-        TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
+        TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FILE
 
     - name: Register Amazon ECS task definition with task definition arn 
       env:
-        TASK_DEF_ARN: ${{ steps.render-task-definition.outputs.task-definition-arn }}
+        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition-arn }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_ARN
 
     - name: Register Amazon ECS task definition with task definition family 
       env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition.outputs.task-definition-family }}
+        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
 
     - name: Register Amazon ECS task definition with task definition family and revision 
       env:
-        TASK_DEF_FAM : ${{ steps.render-task-definition.outputs.task-definition-family }}
-        TASK_DEF_REV : ${{ steps.render-task-definition.outputs.task-definition-revision }}
+        TASK_DEF_FAM : ${{ steps.render-task-definition-family.outputs.task-definition-family }}
+        TASK_DEF_REV : ${{ steps.render-task-definition-revision.outputs.task-definition-revision }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_REV

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -25,7 +25,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
-    - name: Render Amazon ECS task definition with task definition file 
+    - name: Render Amazon ECS task definition with task definition file
       id: render-task-definition-file
       uses: aws-actions/amazon-ecs-render-task-definition@e246ecdd89c8de5a4a8c248830566528cbed06dd
       with:
@@ -33,7 +33,7 @@ jobs:
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
-    - name: Validate Amazon ECS task definition file 
+    - name: Validate Amazon ECS task definition file
       env:
         TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
       run: |
@@ -53,7 +53,7 @@ jobs:
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
-    - name: Render Amazon ECS task definition with task definition family 
+    - name: Render Amazon ECS task definition with task definition family
       id: render-task-definition-family
       uses: aws-actions/amazon-ecs-render-task-definition@e246ecdd89c8de5a4a8c248830566528cbed06dd
       with:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -62,29 +62,29 @@ jobs:
 
     - name: Validate Amazon ECS task definition file 
       env:
-        TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
+        TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
       run: |
         diff expected-task-definition.json $TASK_DEF_FILE
 
     - name: Validate Amazon ECS task definition arn 
       env:
-        TASK_DEF_ARN: ${{ steps.render-task-definition.outputs.task-definition-arn }}
+        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition-arn }}
       run: |
         diff expected-task-definition-arn $TASK_DEF_ARN
 
     - name: Validate Amazon ECS task definition with family 
       env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition.outputs.task-definition-family }}
+        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
       run: |
         diff expected-task-definition-family $TASK_DEF_FAM
     
     - name: Validate Amazon ECS task definition with family and revision
       env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition.outputs.task-definition-family }}
-        TASK_DEF_REV: ${{ steps.render-task-definition.outputs.task-definition-revision }}
+        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
+        TASK_DEF_REV: ${{ steps.render-task-definition-revision.outputs.task-definition-revision }}
       run: |
         diff expected-task-definition-family $TASK_DEF_FAM
-        diff expected-task-definition-family $TASK_DEF_REV
+        diff expected-task-definition-revision $TASK_DEF_REV
 
     #registration
 

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -26,7 +26,7 @@ jobs:
         aws-region: us-west-2
 
     - name: Render Amazon ECS task definition with task definition file 
-      id: render-task-definition
+      id: render-task-definition-file
       uses: aws-actions/amazon-ecs-render-task-definition@964c59d79b99c32ccbda305c9e6afb0cec542076
       with:
         task-definition: task-definition.json
@@ -34,7 +34,7 @@ jobs:
         image: amazon/amazon-ecs-sample:latest
 
     - name: Render Amazon ECS task definition with task definition arn (amazon resource name)
-      id: render-task-definition
+      id: render-task-definition-arn
       uses: aws-actions/amazon-ecs-render-task-definition@964c59d79b99c32ccbda305c9e6afb0cec542076
       with:
         task-definition-arn: task-definition-arn
@@ -42,7 +42,7 @@ jobs:
         image: amazon/amazon-ecs-sample:latest
 
     - name: Render Amazon ECS task definition with task definition family 
-      id: render-task-definition
+      id: render-task-definition-family
       uses: aws-actions/amazon-ecs-render-task-definition@964c59d79b99c32ccbda305c9e6afb0cec542076
       with:
         task-definition-family: task-definition-family
@@ -50,7 +50,7 @@ jobs:
         image: amazon/amazon-ecs-sample:latest
 
     - name: Render Amazon ECS task definition with task definition family and revision
-      id: render-task-definition
+      id: render-task-definition-family-revision
       uses: aws-actions/amazon-ecs-render-task-definition@964c59d79b99c32ccbda305c9e6afb0cec542076
       with:
         task-definition-famiy: task-definition-family

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -33,6 +33,18 @@ jobs:
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
+    - name: Validate Amazon ECS task definition file 
+      env:
+        TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
+      run: |
+        diff expected-task-definition.json $TASK_DEF_FILE
+
+    - name: Register Amazon ECS task definition
+      env:
+        TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
+      run: |
+        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FILE
+
     - name: Render Amazon ECS task definition with task definition arn (amazon resource name)
       id: render-task-definition-arn
       uses: aws-actions/amazon-ecs-render-task-definition@e246ecdd89c8de5a4a8c248830566528cbed06dd
@@ -57,15 +69,3 @@ jobs:
         task-definition-revision: 1
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
-
-    - name: Validate Amazon ECS task definition file 
-      env:
-        TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
-      run: |
-        diff expected-task-definition.json $TASK_DEF_FILE
-
-    - name: Register Amazon ECS task definition
-      env:
-        TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
-      run: |
-        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FILE

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -76,20 +76,20 @@ jobs:
 
     - name: Register Amazon ECS task definition with task definition arn 
       env:
-        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition-arn }}
+        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_ARN
 
     - name: Register Amazon ECS task definition with task definition family 
       env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
+        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
 
     - name: Register Amazon ECS task definition with task definition family and revision 
       env:
-        TASK_DEF_FAM : ${{ steps.render-task-definition-family.outputs.task-definition-family }}
-        TASK_DEF_REV : ${{ steps.render-task-definition-revision.outputs.task-definition-revision }}
+        TASK_DEF_FAM : ${{ steps.render-task-definition-family.outputs.task-definition }}
+        TASK_DEF_REV : ${{ steps.render-task-definition-revision.outputs.task-definition }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_REV

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -45,17 +45,17 @@ jobs:
       id: render-task-definition-family
       uses: shesaave/amazon-ecs-render-task-definition@8a6aa737d95c816e467f33352a951067707a09ab
       with:
-        task-definition-family: task-definition-family
-        container-name: sample-app
+        task-definition-family: fetch-def-task-definition
+        container-name: fetch-app
         image: amazon/amazon-ecs-sample:latest
 
     - name: Render Amazon ECS task definition with task definition family and revision
       id: render-task-definition-family-revision
       uses: shesaave/amazon-ecs-render-task-definition@8a6aa737d95c816e467f33352a951067707a09ab
       with:
-        task-definition-famiy: task-definition-family
-        task-definition-revision: task-definition-revision
-        container-name: sample-app
+        task-definition-famiy: fetch-def-task-definition
+        task-definition-revision: 1
+        container-name: fetch-app
         image: amazon/amazon-ecs-sample:latest
 
     #validation 

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -66,26 +66,6 @@ jobs:
       run: |
         diff expected-task-definition.json $TASK_DEF_FILE
 
-    - name: Validate Amazon ECS task definition arn 
-      env:
-        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition }}
-      run: |
-        diff expected-task-definition.json $TASK_DEF_ARN
-
-    - name: Validate Amazon ECS task definition with family 
-      env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition }}
-      run: |
-        diff expected-task-definition.json $TASK_DEF_FAM
-    
-    - name: Validate Amazon ECS task definition with family and revision
-      env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition }}
-        TASK_DEF_REV: ${{ steps.render-task-definition-revision.outputs.task-definition }}
-      run: |
-        diff expected-task-definition.json $TASK_DEF_FAM
-        diff expected-task-definition.json $TASK_DEF_REV
-
     #registration
 
     - name: Register Amazon ECS task definition with task definition file 

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Render Amazon ECS task definition with task definition file 
       id: render-task-definition-file
-      uses: shesaave/amazon-ecs-render-task-definition@8a6aa737d95c816e467f33352a951067707a09ab
+      uses: aws-actions/amazon-ecs-render-task-definition@e246ecdd89c8de5a4a8c248830566528cbed06dd
       with:
         task-definition: task-definition.json
         container-name: sample-app
@@ -35,27 +35,27 @@ jobs:
 
     - name: Render Amazon ECS task definition with task definition arn (amazon resource name)
       id: render-task-definition-arn
-      uses: shesaave/amazon-ecs-render-task-definition@8a6aa737d95c816e467f33352a951067707a09ab
+      uses: aws-actions/amazon-ecs-render-task-definition@e246ecdd89c8de5a4a8c248830566528cbed06dd
       with:
-        task-definition-arn: arn:aws:ecs:us-west-2:851725652419:task-definition/fetch-def-task-definition:16
-        container-name: fetch-app
+        task-definition-arn: task-definition-arn
+        container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
     - name: Render Amazon ECS task definition with task definition family 
       id: render-task-definition-family
-      uses: shesaave/amazon-ecs-render-task-definition@8a6aa737d95c816e467f33352a951067707a09ab
+      uses: aws-actions/amazon-ecs-render-task-definition@e246ecdd89c8de5a4a8c248830566528cbed06dd
       with:
         task-definition-family: fetch-def-task-definition
-        container-name: fetch-app
+        container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
     - name: Render Amazon ECS task definition with task definition family and revision
       id: render-task-definition-family-revision
-      uses: shesaave/amazon-ecs-render-task-definition@8a6aa737d95c816e467f33352a951067707a09ab
+      uses: aws-actions/amazon-ecs-render-task-definition@e246ecdd89c8de5a4a8c248830566528cbed06dd
       with:
         task-definition-family: fetch-def-task-definition
         task-definition-revision: 1
-        container-name: fetch-app
+        container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
     - name: Validate Amazon ECS task definition file 
@@ -64,10 +64,8 @@ jobs:
       run: |
         diff expected-task-definition.json $TASK_DEF_FILE
 
-    - name: Deploy Amazon ECS task definition with ECS Service
-      uses: aws-actions/amazon-ecs-deploy-task-definition@abe77ebded86b685c231c58bd5936280c6fcc011
-      with:
-        task-definition: ${{ steps.render-task-definition-arn.outputs.task-definition }}
-        service: fetch-def-service
-        cluster: fetch-def-cluster
-        wait-for-service-stability: true
+    - name: Register Amazon ECS task definition
+      env:
+        TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
+      run: |
+        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FILE

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Deploy Amazon ECS task definition with ECS Service
       uses: aws-actions/amazon-ecs-deploy-task-definition@abe77ebded86b685c231c58bd5936280c6fcc011
       with:
-        task-definition: task-definition.json
+        task-definition: ${{ steps.render-task-definition-arn.outputs.task-definition }}
         service: fetch-def-service
         cluster: fetch-def-cluster
         wait-for-service-stability: true

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -59,37 +59,17 @@ jobs:
         image: amazon/amazon-ecs-sample:latest
 
     #validation 
-
     - name: Validate Amazon ECS task definition file 
       env:
         TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
       run: |
         diff expected-task-definition.json $TASK_DEF_FILE
 
-    #registration
-
-    - name: Register Amazon ECS task definition with task definition file 
-      env:
-        TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
-      run: |
-        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FILE
-
-    - name: Register Amazon ECS task definition with task definition arn 
-      env:
-        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition }}
-      run: |
-        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_ARN
-
-    - name: Register Amazon ECS task definition with task definition family 
-      env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition }}
-      run: |
-        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
-
-    - name: Register Amazon ECS task definition with task definition family and revision 
-      env:
-        TASK_DEF_FAM : ${{ steps.render-task-definition-family.outputs.task-definition }}
-        TASK_DEF_REV : ${{ steps.render-task-definition-revision.outputs.task-definition }}
-      run: |
-        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
-        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_REV
+    #deploy
+    - name: Deploy Amazon ECS task definition with ECS Service
+      uses: aws-actions/amazon-ecs-deploy-task-definition@abe77ebded86b685c231c58bd5936280c6fcc011
+      with:
+        task-definition: task-definition.json
+        service: github-actions-deploy-task-def-integ-test
+        cluster: github-actions-deploy-task-def-integ-test
+        wait-for-service-stability: true

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -53,7 +53,7 @@ jobs:
       id: render-task-definition-arn
       uses: aws-actions/amazon-ecs-render-task-definition@e246ecdd89c8de5a4a8c248830566528cbed06dd
       with:
-        task-definition-arn: task-definition-arn
+        task-definition-arn: arn:aws:ecs:us-west-2:397300886559:task-definition/github-actions-render-task-definition-integ-tests:16
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
@@ -61,7 +61,7 @@ jobs:
       id: render-task-definition-family
       uses: aws-actions/amazon-ecs-render-task-definition@e246ecdd89c8de5a4a8c248830566528cbed06dd
       with:
-        task-definition-family: task-definition-family
+        task-definition-family: github-actions-render-task-definition-integ-tests
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
@@ -69,7 +69,7 @@ jobs:
       id: render-task-definition-family-revision
       uses: aws-actions/amazon-ecs-render-task-definition@e246ecdd89c8de5a4a8c248830566528cbed06dd
       with:
-        task-definition-family: task-definition-family
+        task-definition-family: github-actions-render-task-definition-integ-tests
         task-definition-revision: 1
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -70,21 +70,21 @@ jobs:
       env:
         TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition-arn }}
       run: |
-        diff expected-task-definition-arn $TASK_DEF_ARN
+        diff expected-task-definition.json $TASK_DEF_ARN
 
     - name: Validate Amazon ECS task definition with family 
       env:
         TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
       run: |
-        diff expected-task-definition-family $TASK_DEF_FAM
+        diff expected-task-definition.json $TASK_DEF_FAM
     
     - name: Validate Amazon ECS task definition with family and revision
       env:
         TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
         TASK_DEF_REV: ${{ steps.render-task-definition-revision.outputs.task-definition-revision }}
       run: |
-        diff expected-task-definition-family $TASK_DEF_FAM
-        diff expected-task-definition-revision $TASK_DEF_REV
+        diff expected-task-definition.json $TASK_DEF_FAM
+        diff expected-task-definition.json $TASK_DEF_REV
 
     #registration
 

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Register Amazon ECS task definition
       env:
-        TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
+        TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FILE
 

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         diff expected-task-definition.json $TASK_DEF_FILE
 
-    - name: Register Amazon ECS task definition
+    - name: Register Amazon ECS task definition file
       env:
         TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
       run: |

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -53,7 +53,7 @@ jobs:
       id: render-task-definition-family-revision
       uses: shesaave/amazon-ecs-render-task-definition@8a6aa737d95c816e467f33352a951067707a09ab
       with:
-        task-definition-famiy: fetch-def-task-definition
+        task-definition-family: fetch-def-task-definition
         task-definition-revision: 1
         container-name: fetch-app
         image: amazon/amazon-ecs-sample:latest

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -58,14 +58,12 @@ jobs:
         container-name: fetch-app
         image: amazon/amazon-ecs-sample:latest
 
-    #validation 
     - name: Validate Amazon ECS task definition file 
       env:
         TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
       run: |
         diff expected-task-definition.json $TASK_DEF_FILE
 
-    #deploy
     - name: Deploy Amazon ECS task definition with ECS Service
       uses: aws-actions/amazon-ecs-deploy-task-definition@abe77ebded86b685c231c58bd5936280c6fcc011
       with:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -57,7 +57,7 @@ jobs:
       id: render-task-definition-family
       uses: aws-actions/amazon-ecs-render-task-definition@e246ecdd89c8de5a4a8c248830566528cbed06dd
       with:
-        task-definition-family: fetch-def-task-definition
+        task-definition-family: task-definition-family
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
@@ -65,7 +65,7 @@ jobs:
       id: render-task-definition-family-revision
       uses: aws-actions/amazon-ecs-render-task-definition@e246ecdd89c8de5a4a8c248830566528cbed06dd
       with:
-        task-definition-family: fetch-def-task-definition
+        task-definition-family: task-definition-family
         task-definition-revision: 1
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -28,7 +28,7 @@ jobs:
         role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/GitHubActionsRenderTaskIntegrationTests
         role-session-name: render_task_integration_tests
         aws-region: us-west-2
-        
+
     - name: Render Amazon ECS task definition with task definition file
       id: render-task-definition-file
       uses: aws-actions/amazon-ecs-render-task-definition@e246ecdd89c8de5a4a8c248830566528cbed06dd

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Render Amazon ECS task definition with task definition file 
       id: render-task-definition-file
-      uses: aws-actions/amazon-ecs-render-task-definition@964c59d79b99c32ccbda305c9e6afb0cec542076
+      uses: shesaave/amazon-ecs-render-task-definition@8a6aa737d95c816e467f33352a951067707a09ab
       with:
         task-definition: task-definition.json
         container-name: sample-app
@@ -35,7 +35,7 @@ jobs:
 
     - name: Render Amazon ECS task definition with task definition arn (amazon resource name)
       id: render-task-definition-arn
-      uses: aws-actions/amazon-ecs-render-task-definition@964c59d79b99c32ccbda305c9e6afb0cec542076
+      uses: shesaave/amazon-ecs-render-task-definition@8a6aa737d95c816e467f33352a951067707a09ab
       with:
         task-definition-arn: task-definition-arn
         container-name: sample-app
@@ -43,7 +43,7 @@ jobs:
 
     - name: Render Amazon ECS task definition with task definition family 
       id: render-task-definition-family
-      uses: aws-actions/amazon-ecs-render-task-definition@964c59d79b99c32ccbda305c9e6afb0cec542076
+      uses: shesaave/amazon-ecs-render-task-definition@8a6aa737d95c816e467f33352a951067707a09ab
       with:
         task-definition-family: task-definition-family
         container-name: sample-app
@@ -51,7 +51,7 @@ jobs:
 
     - name: Render Amazon ECS task definition with task definition family and revision
       id: render-task-definition-family-revision
-      uses: aws-actions/amazon-ecs-render-task-definition@964c59d79b99c32ccbda305c9e6afb0cec542076
+      uses: shesaave/amazon-ecs-render-task-definition@8a6aa737d95c816e467f33352a951067707a09ab
       with:
         task-definition-famiy: task-definition-family
         task-definition-revision: task-definition-revision

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -60,29 +60,29 @@ jobs:
 
     - name: Validate Amazon ECS task definition file 
       env:
-        TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
+        TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
       run: |
         diff expected-task-definition.json $TASK_DEF_FILE
 
     - name: Validate Amazon ECS task definition arn 
       env:
-        TASK_DEF_ARN: ${{ steps.render-task-definition.outputs.task-definition-arn }}
+        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition-arn }}
       run: |
         diff expected-task-definition-arn $TASK_DEF_ARN
 
     - name: Validate Amazon ECS task definition with family 
       env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition.outputs.task-definition-family }}
+        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
       run: |
         diff expected-task-definition-family $TASK_DEF_FAM
     
     - name: Validate Amazon ECS task definition with family and revision
       env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition.outputs.task-definition-family }}
-        TASK_DEF_REV: ${{ steps.render-task-definition.outputs.task-definition-revision }}
+        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
+        TASK_DEF_REV: ${{ steps.render-task-definition-revision.outputs.task-definition-revision }}
       run: |
         diff expected-task-definition-family $TASK_DEF_FAM
-        diff expected-task-definition-family $TASK_DEF_REV
+        diff expected-task-definition-revision $TASK_DEF_REV
 
     - name: Register Amazon ECS task definition with task definition file 
       env:

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -68,21 +68,21 @@ jobs:
       env:
         TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition-arn }}
       run: |
-        diff expected-task-definition-arn $TASK_DEF_ARN
+        diff expected-task-definition.json $TASK_DEF_ARN
 
     - name: Validate Amazon ECS task definition with family 
       env:
         TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
       run: |
-        diff expected-task-definition-family $TASK_DEF_FAM
+        diff expected-task-definition.json $TASK_DEF_FAM
     
     - name: Validate Amazon ECS task definition with family and revision
       env:
         TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
         TASK_DEF_REV: ${{ steps.render-task-definition-revision.outputs.task-definition-revision }}
       run: |
-        diff expected-task-definition-family $TASK_DEF_FAM
-        diff expected-task-definition-revision $TASK_DEF_REV
+        diff expected-task-definition.json $TASK_DEF_FAM
+        diff expected-task-definition.json $TASK_DEF_REV
 
     - name: Register Amazon ECS task definition with task definition file 
       env:

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Render Amazon ECS task definition with task definition file 
       id: render-task-definition-file
-      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      uses: shesaave/amazon-ecs-render-task-definition@v1
       with:
         task-definition: task-definition.json
         container-name: sample-app
@@ -35,7 +35,7 @@ jobs:
 
     - name: Render Amazon ECS task definition with task definition arn (amazon resource name)
       id: render-task-definition-arn
-      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      uses: shesaave/amazon-ecs-render-task-definition@v1
       with:
         task-definition-arn: task-definition-arn
         container-name: sample-app
@@ -43,7 +43,7 @@ jobs:
 
     - name: Render Amazon ECS task definition with task definition family 
       id: render-task-definition-family
-      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      uses: shesaave/amazon-ecs-render-task-definition@v1
       with:
         task-definition-family: task-definition-family
         container-name: sample-app
@@ -51,7 +51,7 @@ jobs:
 
     - name: Render Amazon ECS task definition with task definition family and revision
       id: render-task-definition-family-revision
-      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      uses: shesaave/amazon-ecs-render-task-definition@v1
       with:
         task-definition-famiy: task-definition-family
         task-definition-revision: task-definition-revision

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -66,26 +66,26 @@ jobs:
 
     - name: Register Amazon ECS task definition with task definition file 
       env:
-        TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
+        TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FILE
 
     - name: Register Amazon ECS task definition with task definition arn 
       env:
-        TASK_DEF_ARN: ${{ steps.render-task-definition.outputs.task-definition-arn }}
+        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition-arn }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_ARN
 
     - name: Register Amazon ECS task definition with task definition family 
       env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition.outputs.task-definition-family }}
+        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
 
     - name: Register Amazon ECS task definition with task definition family and revision 
       env:
-        TASK_DEF_FAM : ${{ steps.render-task-definition.outputs.task-definition-family }}
-        TASK_DEF_REV : ${{ steps.render-task-definition.outputs.task-definition-revision }}
+        TASK_DEF_FAM : ${{ steps.render-task-definition-family.outputs.task-definition-family }}
+        TASK_DEF_REV : ${{ steps.render-task-definition-revision.outputs.task-definition-revision }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_REV

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -27,34 +27,9 @@ jobs:
 
     - name: Render Amazon ECS task definition with task definition file 
       id: render-task-definition-file
-      uses: shesaave/amazon-ecs-render-task-definition@v1
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition: task-definition.json
-        container-name: sample-app
-        image: amazon/amazon-ecs-sample:latest
-
-    - name: Render Amazon ECS task definition with task definition arn (amazon resource name)
-      id: render-task-definition-arn
-      uses: shesaave/amazon-ecs-render-task-definition@v1
-      with:
-        task-definition-arn: task-definition-arn
-        container-name: sample-app
-        image: amazon/amazon-ecs-sample:latest
-
-    - name: Render Amazon ECS task definition with task definition family 
-      id: render-task-definition-family
-      uses: shesaave/amazon-ecs-render-task-definition@v1
-      with:
-        task-definition-family: task-definition-family
-        container-name: sample-app
-        image: amazon/amazon-ecs-sample:latest
-
-    - name: Render Amazon ECS task definition with task definition family and revision
-      id: render-task-definition-family-revision
-      uses: shesaave/amazon-ecs-render-task-definition@v1
-      with:
-        task-definition-family: task-definition-family
-        task-definition-revision: 1
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
@@ -70,4 +45,27 @@ jobs:
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FILE
 
-   
+    - name: Render Amazon ECS task definition with task definition arn (amazon resource name)
+      id: render-task-definition-arn
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition-arn: task-definition-arn
+        container-name: sample-app
+        image: amazon/amazon-ecs-sample:latest
+
+    - name: Render Amazon ECS task definition with task definition family 
+      id: render-task-definition-family
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition-family: task-definition-family
+        container-name: sample-app
+        image: amazon/amazon-ecs-sample:latest
+
+    - name: Render Amazon ECS task definition with task definition family and revision
+      id: render-task-definition-family-revision
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition-family: task-definition-family
+        task-definition-revision: 1
+        container-name: sample-app
+        image: amazon/amazon-ecs-sample:latest

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -35,13 +35,13 @@ jobs:
 
     - name: Validate Amazon ECS task definition
       env:
-        TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
+        TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
       run: |
         diff expected-task-definition.json $TASK_DEF_FILE
 
     - name: Register Amazon ECS task definition
       env:
-        TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
+        TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FILE
 

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -37,7 +37,7 @@ jobs:
       id: render-task-definition-arn
       uses: shesaave/amazon-ecs-render-task-definition@v1
       with:
-        task-definition-arn: task-definition-arn
+        task-definition-arn: arn:aws:ecs:us-west-2:851725652419:task-definition/fetch-def-task-definition:16
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -53,7 +53,7 @@ jobs:
       id: render-task-definition-arn
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
-        task-definition-arn: task-definition-arn
+        task-definition-arn: arn:aws:ecs:us-west-2:397300886559:task-definition/github-actions-render-task-definition-integ-tests:16
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
@@ -61,7 +61,7 @@ jobs:
       id: render-task-definition-family
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
-        task-definition-family: task-definition-family
+        task-definition-family: github-actions-render-task-definition-integ-tests
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
@@ -69,7 +69,7 @@ jobs:
       id: render-task-definition-family-revision
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
-        task-definition-family: task-definition-family
+        task-definition-family: github-actions-render-task-definition-integ-tests
         task-definition-revision: 1
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Deploy Amazon ECS task definition with ECS Service
       uses: aws-actions/amazon-ecs-deploy-task-definition@abe77ebded86b685c231c58bd5936280c6fcc011
       with:
-        task-definition: task-definition.json
+        task-definition: ${{ steps.render-task-definition-arn.outputs.task-definition }}
         service: fetch-def-service
         cluster: fetch-def-cluster
         wait-for-service-stability: true

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -64,26 +64,6 @@ jobs:
       run: |
         diff expected-task-definition.json $TASK_DEF_FILE
 
-    - name: Validate Amazon ECS task definition arn 
-      env:
-        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition }}
-      run: |
-        diff expected-task-definition.json $TASK_DEF_ARN
-
-    - name: Validate Amazon ECS task definition with family 
-      env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition }}
-      run: |
-        diff expected-task-definition.json $TASK_DEF_FAM
-    
-    - name: Validate Amazon ECS task definition with family and revision
-      env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition }}
-        TASK_DEF_REV: ${{ steps.render-task-definition-revision.outputs.task-definition }}
-      run: |
-        diff expected-task-definition.json $TASK_DEF_FAM
-        diff expected-task-definition.json $TASK_DEF_REV
-
     - name: Register Amazon ECS task definition with task definition file 
       env:
         TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -26,7 +26,7 @@ jobs:
         aws-region: us-west-2
 
     - name: Render Amazon ECS task definition with task definition file 
-      id: render-task-definition
+      id: render-task-definition-file
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition: task-definition.json
@@ -34,7 +34,7 @@ jobs:
         image: amazon/amazon-ecs-sample:latest
 
     - name: Render Amazon ECS task definition with task definition arn (amazon resource name)
-      id: render-task-definition
+      id: render-task-definition-arn
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition-arn: task-definition-arn
@@ -42,7 +42,7 @@ jobs:
         image: amazon/amazon-ecs-sample:latest
 
     - name: Render Amazon ECS task definition with task definition family 
-      id: render-task-definition
+      id: render-task-definition-family
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition-family: task-definition-family
@@ -50,7 +50,7 @@ jobs:
         image: amazon/amazon-ecs-sample:latest
 
     - name: Render Amazon ECS task definition with task definition family and revision
-      id: render-task-definition
+      id: render-task-definition-family-revision
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition-famiy: task-definition-family

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -53,7 +53,7 @@ jobs:
       id: render-task-definition-family-revision
       uses: shesaave/amazon-ecs-render-task-definition@v1
       with:
-        task-definition-famiy: fetch-def-task-definition
+        task-definition-family: fetch-def-task-definition
         task-definition-revision: 1
         container-name: fetch-app
         image: amazon/amazon-ecs-sample:latest

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -38,24 +38,24 @@ jobs:
       uses: shesaave/amazon-ecs-render-task-definition@v1
       with:
         task-definition-arn: arn:aws:ecs:us-west-2:851725652419:task-definition/fetch-def-task-definition:16
-        container-name: sample-app
+        container-name: fetch-app
         image: amazon/amazon-ecs-sample:latest
 
     - name: Render Amazon ECS task definition with task definition family 
       id: render-task-definition-family
       uses: shesaave/amazon-ecs-render-task-definition@v1
       with:
-        task-definition-family: task-definition-family
-        container-name: sample-app
+        task-definition-family: fetch-def-task-definition
+        container-name: fetch-app
         image: amazon/amazon-ecs-sample:latest
 
     - name: Render Amazon ECS task definition with task definition family and revision
       id: render-task-definition-family-revision
       uses: shesaave/amazon-ecs-render-task-definition@v1
       with:
-        task-definition-famiy: task-definition-family
-        task-definition-revision: task-definition-revision
-        container-name: sample-app
+        task-definition-famiy: fetch-def-task-definition
+        task-definition-revision: 1
+        container-name: fetch-app
         image: amazon/amazon-ecs-sample:latest
 
     - name: Validate Amazon ECS task definition file 

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -25,7 +25,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
-    - name: Render Amazon ECS task definition with task definition file 
+    - name: Render Amazon ECS task definition with task definition file
       id: render-task-definition-file
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
@@ -53,7 +53,7 @@ jobs:
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
-    - name: Render Amazon ECS task definition with task definition family 
+    - name: Render Amazon ECS task definition with task definition family
       id: render-task-definition-family
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -63,8 +63,8 @@ jobs:
       uses: aws-actions/amazon-ecs-deploy-task-definition@abe77ebded86b685c231c58bd5936280c6fcc011
       with:
         task-definition: task-definition.json
-        service: github-actions-deploy-task-def-integ-test
-        cluster: github-actions-deploy-task-def-integ-test
+        service: fetch-def-service
+        cluster: fetch-def-cluster
         wait-for-service-stability: true
 
    

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -58,7 +58,6 @@ jobs:
         container-name: fetch-app
         image: amazon/amazon-ecs-sample:latest
 
-    #deploy
     - name: Deploy Amazon ECS task definition with ECS Service
       uses: aws-actions/amazon-ecs-deploy-task-definition@abe77ebded86b685c231c58bd5936280c6fcc011
       with:

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -58,34 +58,13 @@ jobs:
         container-name: fetch-app
         image: amazon/amazon-ecs-sample:latest
 
-    - name: Validate Amazon ECS task definition file 
-      env:
-        TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
-      run: |
-        diff expected-task-definition.json $TASK_DEF_FILE
+    #deploy
+    - name: Deploy Amazon ECS task definition with ECS Service
+      uses: aws-actions/amazon-ecs-deploy-task-definition@abe77ebded86b685c231c58bd5936280c6fcc011
+      with:
+        task-definition: task-definition.json
+        service: github-actions-deploy-task-def-integ-test
+        cluster: github-actions-deploy-task-def-integ-test
+        wait-for-service-stability: true
 
-    - name: Register Amazon ECS task definition with task definition file 
-      env:
-        TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
-      run: |
-        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FILE
-
-    - name: Register Amazon ECS task definition with task definition arn 
-      env:
-        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition }}
-      run: |
-        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_ARN
-
-    - name: Register Amazon ECS task definition with task definition family 
-      env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition }}
-      run: |
-        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
-
-    - name: Register Amazon ECS task definition with task definition family and revision 
-      env:
-        TASK_DEF_FAM : ${{ steps.render-task-definition-family.outputs.task-definition }}
-        TASK_DEF_REV : ${{ steps.render-task-definition-revision.outputs.task-definition }}
-      run: |
-        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
-        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_REV
+   

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -72,20 +72,20 @@ jobs:
 
     - name: Register Amazon ECS task definition with task definition arn 
       env:
-        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition-arn }}
+        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_ARN
 
     - name: Register Amazon ECS task definition with task definition family 
       env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
+        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
 
     - name: Register Amazon ECS task definition with task definition family and revision 
       env:
-        TASK_DEF_FAM : ${{ steps.render-task-definition-family.outputs.task-definition-family }}
-        TASK_DEF_REV : ${{ steps.render-task-definition-revision.outputs.task-definition-revision }}
+        TASK_DEF_FAM : ${{ steps.render-task-definition-family.outputs.task-definition }}
+        TASK_DEF_REV : ${{ steps.render-task-definition-revision.outputs.task-definition }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_REV

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -37,33 +37,37 @@ jobs:
       id: render-task-definition-arn
       uses: shesaave/amazon-ecs-render-task-definition@v1
       with:
-        task-definition-arn: arn:aws:ecs:us-west-2:851725652419:task-definition/fetch-def-task-definition:16
-        container-name: fetch-app
+        task-definition-arn: task-definition-arn
+        container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
     - name: Render Amazon ECS task definition with task definition family 
       id: render-task-definition-family
       uses: shesaave/amazon-ecs-render-task-definition@v1
       with:
-        task-definition-family: fetch-def-task-definition
-        container-name: fetch-app
+        task-definition-family: task-definition-family
+        container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
     - name: Render Amazon ECS task definition with task definition family and revision
       id: render-task-definition-family-revision
       uses: shesaave/amazon-ecs-render-task-definition@v1
       with:
-        task-definition-family: fetch-def-task-definition
+        task-definition-family: task-definition-family
         task-definition-revision: 1
-        container-name: fetch-app
+        container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
-    - name: Deploy Amazon ECS task definition with ECS Service
-      uses: aws-actions/amazon-ecs-deploy-task-definition@abe77ebded86b685c231c58bd5936280c6fcc011
-      with:
-        task-definition: ${{ steps.render-task-definition-arn.outputs.task-definition }}
-        service: fetch-def-service
-        cluster: fetch-def-cluster
-        wait-for-service-stability: true
+    - name: Validate Amazon ECS task definition
+      env:
+        TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
+      run: |
+        diff expected-task-definition.json $TASK_DEF_FILE
+
+    - name: Register Amazon ECS task definition
+      env:
+        TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
+      run: |
+        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FILE
 
    

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -25,7 +25,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
-    - name: Render Amazon ECS task definition
+    - name: Render Amazon ECS task definition with task definition file 
       id: render-task-definition
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
@@ -33,14 +33,79 @@ jobs:
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
-    - name: Validate Amazon ECS task definition
+    - name: Render Amazon ECS task definition with task definition arn (amazon resource name)
+      id: render-task-definition
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition-arn: task-definition-arn
+        container-name: sample-app
+        image: amazon/amazon-ecs-sample:latest
+
+    - name: Render Amazon ECS task definition with task definition family 
+      id: render-task-definition
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition-family: task-definition-family
+        container-name: sample-app
+        image: amazon/amazon-ecs-sample:latest
+
+    - name: Render Amazon ECS task definition with task definition family and revision
+      id: render-task-definition
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition-famiy: task-definition-family
+        task-definition-revision: task-definition-revision
+        container-name: sample-app
+        image: amazon/amazon-ecs-sample:latest
+
+    - name: Validate Amazon ECS task definition file 
       env:
         TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
       run: |
         diff expected-task-definition.json $TASK_DEF_FILE
 
-    - name: Register Amazon ECS task definition
+    - name: Validate Amazon ECS task definition arn 
+      env:
+        TASK_DEF_ARN: ${{ steps.render-task-definition.outputs.task-definition-arn }}
+      run: |
+        diff expected-task-definition-arn $TASK_DEF_ARN
+
+    - name: Validate Amazon ECS task definition with family 
+      env:
+        TASK_DEF_FAM: ${{ steps.render-task-definition.outputs.task-definition-family }}
+      run: |
+        diff expected-task-definition-family $TASK_DEF_FAM
+    
+    - name: Validate Amazon ECS task definition with family and revision
+      env:
+        TASK_DEF_FAM: ${{ steps.render-task-definition.outputs.task-definition-family }}
+        TASK_DEF_REV: ${{ steps.render-task-definition.outputs.task-definition-revision }}
+      run: |
+        diff expected-task-definition-family $TASK_DEF_FAM
+        diff expected-task-definition-family $TASK_DEF_REV
+
+    - name: Register Amazon ECS task definition with task definition file 
       env:
         TASK_DEF_FILE: ${{ steps.render-task-definition.outputs.task-definition }}
       run: |
         aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FILE
+
+    - name: Register Amazon ECS task definition with task definition arn 
+      env:
+        TASK_DEF_ARN: ${{ steps.render-task-definition.outputs.task-definition-arn }}
+      run: |
+        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_ARN
+
+    - name: Register Amazon ECS task definition with task definition family 
+      env:
+        TASK_DEF_FAM: ${{ steps.render-task-definition.outputs.task-definition-family }}
+      run: |
+        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
+
+    - name: Register Amazon ECS task definition with task definition family and revision 
+      env:
+        TASK_DEF_FAM : ${{ steps.render-task-definition.outputs.task-definition-family }}
+        TASK_DEF_REV : ${{ steps.render-task-definition.outputs.task-definition-revision }}
+      run: |
+        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_FAM
+        aws ecs register-task-definition --cli-input-json file://$TASK_DEF_REV

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -33,13 +33,13 @@ jobs:
         container-name: sample-app
         image: amazon/amazon-ecs-sample:latest
 
-    - name: Validate Amazon ECS task definition
+    - name: Validate Amazon ECS task definition file
       env:
         TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
       run: |
         diff expected-task-definition.json $TASK_DEF_FILE
 
-    - name: Register Amazon ECS task definition
+    - name: Register Amazon ECS task definition file
       env:
         TASK_DEF_FILE: ${{ steps.render-task-definition-file.outputs.task-definition }}
       run: |

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -66,20 +66,20 @@ jobs:
 
     - name: Validate Amazon ECS task definition arn 
       env:
-        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition-arn }}
+        TASK_DEF_ARN: ${{ steps.render-task-definition-arn.outputs.task-definition }}
       run: |
         diff expected-task-definition.json $TASK_DEF_ARN
 
     - name: Validate Amazon ECS task definition with family 
       env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
+        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition }}
       run: |
         diff expected-task-definition.json $TASK_DEF_FAM
     
     - name: Validate Amazon ECS task definition with family and revision
       env:
-        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition-family }}
-        TASK_DEF_REV: ${{ steps.render-task-definition-revision.outputs.task-definition-revision }}
+        TASK_DEF_FAM: ${{ steps.render-task-definition-family.outputs.task-definition }}
+        TASK_DEF_REV: ${{ steps.render-task-definition-revision.outputs.task-definition }}
       run: |
         diff expected-task-definition.json $TASK_DEF_FAM
         diff expected-task-definition.json $TASK_DEF_REV


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-actions/amazon-ecs-render-task-definition/pull/311

*Description of changes:*
- adding new options to fetch task definition: task definition ARN, task definition family, and task definition revision
- testing options and deployment 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
