### PR TITLE
fix: secrets handled without environment-variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,45 +171,45 @@ async function run() {
           containerDef.environment.push(variable);
         }
       })
+    }
 
-      if (secrets) {
-        // If secrets array is missing, create it
-        if (!Array.isArray(containerDef.secrets)) {
-          containerDef.secrets = [];
-        }
-
-        // Get pairs by splitting on newlines
-        secrets.split('\n').forEach(function (line) {
-          // Trim whitespace
-          const trimmedLine = line.trim();
-          // Skip if empty
-          if (trimmedLine.length === 0) { return; }
-          // Split on =
-          const separatorIdx = trimmedLine.indexOf("=");
-          // If there's nowhere to split
-          if (separatorIdx === -1) {
-              throw new Error(
-                `Cannot parse the secret '${trimmedLine}'. Secret pairs must be of the form NAME=valueFrom, 
-                where valueFrom is an arn from parameter store or secrets manager. See AWS documentation for more information: 
-                https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html.`);
-          }
-          // Build object
-          const secret = {
-            name: trimmedLine.substring(0, separatorIdx),
-            valueFrom: trimmedLine.substring(separatorIdx + 1),
-          };
-
-          // Search container definition environment for one matching name
-          const secretDef = containerDef.secrets.find((s) => s.name == secret.name);
-          if (secretDef) {
-            // If found, update
-            secretDef.valueFrom = secret.valueFrom;
-          } else {
-            // Else, create
-            containerDef.secrets.push(secret);
-          }
-        })
+    if (secrets) {
+      // If secrets array is missing, create it
+      if (!Array.isArray(containerDef.secrets)) {
+        containerDef.secrets = [];
       }
+
+      // Get pairs by splitting on newlines
+      secrets.split('\n').forEach(function (line) {
+        // Trim whitespace
+        const trimmedLine = line.trim();
+        // Skip if empty
+        if (trimmedLine.length === 0) { return; }
+        // Split on =
+        const separatorIdx = trimmedLine.indexOf("=");
+        // If there's nowhere to split
+        if (separatorIdx === -1) {
+          throw new Error(
+              `Cannot parse the secret '${trimmedLine}'. Secret pairs must be of the form NAME=valueFrom, 
+              where valueFrom is an arn from parameter store or secrets manager. See AWS documentation for more information: 
+              https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html.`);
+        }
+        // Build object
+        const secret = {
+          name: trimmedLine.substring(0, separatorIdx),
+          valueFrom: trimmedLine.substring(separatorIdx + 1),
+        };
+
+        // Search container definition environment for one matching name
+        const secretDef = containerDef.secrets.find((s) => s.name == secret.name);
+        if (secretDef) {
+          // If found, update
+          secretDef.valueFrom = secret.valueFrom;
+        } else {
+          // Else, create
+          containerDef.secrets.push(secret);
+        }
+      })
     }
 
     if (logConfigurationLogDriver) {

--- a/index.test.js
+++ b/index.test.js
@@ -315,6 +315,56 @@ describe('Render task definition', () => {
         expect(mockEcsDescribeTaskDef).toHaveBeenCalledTimes(0);
     });
 
+    test('renders secrets even if environment-variables is empty', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('/secrets/task-definition.json') // task-definition
+            .mockReturnValueOnce('web')                  // container-name
+            .mockReturnValueOnce('nginx:latest')         // image
+            .mockReturnValueOnce('')                     // environment-variables
+            .mockReturnValueOnce('')                     // env-files
+            .mockReturnValueOnce('')                     // log Configuration Log Driver
+            .mockReturnValueOnce('')                     // log Configuration Options
+            .mockReturnValueOnce('')                     // docker labels
+            .mockReturnValueOnce('')                     // command
+            .mockReturnValueOnce('')                     // task-definition arn
+            .mockReturnValueOnce('')                     // task-definition family
+            .mockReturnValueOnce('')                     // task-definition revision
+            .mockReturnValueOnce('NEW_SECRET=arn:aws:ssm:region:0123456789:parameter/secret'); // secrets
+
+        jest.mock('/secrets/task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "old-image"
+                }
+            ]
+        }), { virtual: true });
+
+        await run();
+
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest",
+                        secrets: [
+                            {
+                                name: "NEW_SECRET",
+                                valueFrom: "arn:aws:ssm:region:0123456789:parameter/secret"
+                            }
+                        ]
+                    }
+                ]
+            }, null, 2)
+        );
+
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
+    });
+
     test('renders logConfiguration on the task definition', async () => {
         core.getInput = jest
             .fn()


### PR DESCRIPTION
*Issue #347 

*Description of changes:*

This PR fixes a bug where secrets were not being rendered in the generated task definition if the environment-variables input was empty or missing.

* Added Regression Test
* Decoupled the logic

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
