### PR TITLE
fix: upgrade Node.js runtime from 20 to 24

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Node setup
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 24
     - name: Run tests
       run: |
         npm ci

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Node setup
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Package
         run: |
           npm ci

--- a/action.yml
+++ b/action.yml
@@ -47,5 +47,5 @@ outputs:
   task-definition:
     description: 'The path to the rendered task definition file'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
Node.js 20 actions are deprecated and will be forced to run with Node.js 24 starting June 2nd, 2026.

- Update action.yml runtime from node20 to node24
- Update CI workflows to use Node.js 24

Fixes #454

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
