### PR TITLE
fix: allow secrets to render without environment-variables

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -177,45 +177,45 @@ async function run() {
           containerDef.environment.push(variable);
         }
       })
+    }
 
-      if (secrets) {
-        // If secrets array is missing, create it
-        if (!Array.isArray(containerDef.secrets)) {
-          containerDef.secrets = [];
-        }
-
-        // Get pairs by splitting on newlines
-        secrets.split('\n').forEach(function (line) {
-          // Trim whitespace
-          const trimmedLine = line.trim();
-          // Skip if empty
-          if (trimmedLine.length === 0) { return; }
-          // Split on =
-          const separatorIdx = trimmedLine.indexOf("=");
-          // If there's nowhere to split
-          if (separatorIdx === -1) {
-              throw new Error(
-                `Cannot parse the secret '${trimmedLine}'. Secret pairs must be of the form NAME=valueFrom, 
-                where valueFrom is an arn from parameter store or secrets manager. See AWS documentation for more information: 
-                https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html.`);
-          }
-          // Build object
-          const secret = {
-            name: trimmedLine.substring(0, separatorIdx),
-            valueFrom: trimmedLine.substring(separatorIdx + 1),
-          };
-
-          // Search container definition environment for one matching name
-          const secretDef = containerDef.secrets.find((s) => s.name == secret.name);
-          if (secretDef) {
-            // If found, update
-            secretDef.valueFrom = secret.valueFrom;
-          } else {
-            // Else, create
-            containerDef.secrets.push(secret);
-          }
-        })
+    if (secrets) {
+      // If secrets array is missing, create it
+      if (!Array.isArray(containerDef.secrets)) {
+        containerDef.secrets = [];
       }
+
+      // Get pairs by splitting on newlines
+      secrets.split('\n').forEach(function (line) {
+        // Trim whitespace
+        const trimmedLine = line.trim();
+        // Skip if empty
+        if (trimmedLine.length === 0) { return; }
+        // Split on =
+        const separatorIdx = trimmedLine.indexOf("=");
+        // If there's nowhere to split
+        if (separatorIdx === -1) {
+            throw new Error(
+              `Cannot parse the secret '${trimmedLine}'. Secret pairs must be of the form NAME=valueFrom, 
+              where valueFrom is an arn from parameter store or secrets manager. See AWS documentation for more information: 
+              https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html.`);
+        }
+        // Build object
+        const secret = {
+          name: trimmedLine.substring(0, separatorIdx),
+          valueFrom: trimmedLine.substring(separatorIdx + 1),
+        };
+
+        // Search container definition environment for one matching name
+        const secretDef = containerDef.secrets.find((s) => s.name == secret.name);
+        if (secretDef) {
+          // If found, update
+          secretDef.valueFrom = secret.valueFrom;
+        } else {
+          // Else, create
+          containerDef.secrets.push(secret);
+        }
+      })
     }
 
     if (logConfigurationLogDriver) {

--- a/index.js
+++ b/index.js
@@ -171,45 +171,45 @@ async function run() {
           containerDef.environment.push(variable);
         }
       })
+    }
 
-      if (secrets) {
-        // If secrets array is missing, create it
-        if (!Array.isArray(containerDef.secrets)) {
-          containerDef.secrets = [];
-        }
-
-        // Get pairs by splitting on newlines
-        secrets.split('\n').forEach(function (line) {
-          // Trim whitespace
-          const trimmedLine = line.trim();
-          // Skip if empty
-          if (trimmedLine.length === 0) { return; }
-          // Split on =
-          const separatorIdx = trimmedLine.indexOf("=");
-          // If there's nowhere to split
-          if (separatorIdx === -1) {
-              throw new Error(
-                `Cannot parse the secret '${trimmedLine}'. Secret pairs must be of the form NAME=valueFrom, 
-                where valueFrom is an arn from parameter store or secrets manager. See AWS documentation for more information: 
-                https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html.`);
-          }
-          // Build object
-          const secret = {
-            name: trimmedLine.substring(0, separatorIdx),
-            valueFrom: trimmedLine.substring(separatorIdx + 1),
-          };
-
-          // Search container definition environment for one matching name
-          const secretDef = containerDef.secrets.find((s) => s.name == secret.name);
-          if (secretDef) {
-            // If found, update
-            secretDef.valueFrom = secret.valueFrom;
-          } else {
-            // Else, create
-            containerDef.secrets.push(secret);
-          }
-        })
+    if (secrets) {
+      // If secrets array is missing, create it
+      if (!Array.isArray(containerDef.secrets)) {
+        containerDef.secrets = [];
       }
+
+      // Get pairs by splitting on newlines
+      secrets.split('\n').forEach(function (line) {
+        // Trim whitespace
+        const trimmedLine = line.trim();
+        // Skip if empty
+        if (trimmedLine.length === 0) { return; }
+        // Split on =
+        const separatorIdx = trimmedLine.indexOf("=");
+        // If there's nowhere to split
+        if (separatorIdx === -1) {
+            throw new Error(
+              `Cannot parse the secret '${trimmedLine}'. Secret pairs must be of the form NAME=valueFrom, 
+              where valueFrom is an arn from parameter store or secrets manager. See AWS documentation for more information: 
+              https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html.`);
+        }
+        // Build object
+        const secret = {
+          name: trimmedLine.substring(0, separatorIdx),
+          valueFrom: trimmedLine.substring(separatorIdx + 1),
+        };
+
+        // Search container definition environment for one matching name
+        const secretDef = containerDef.secrets.find((s) => s.name == secret.name);
+        if (secretDef) {
+          // If found, update
+          secretDef.valueFrom = secret.valueFrom;
+        } else {
+          // Else, create
+          containerDef.secrets.push(secret);
+        }
+      })
     }
 
     if (logConfigurationLogDriver) {

--- a/index.test.js
+++ b/index.test.js
@@ -1003,4 +1003,66 @@ describe('Render task definition', () => {
             }, null, 2)
         );
     });
+
+    test('renders secrets without environment-variables', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('/hello/secrets-only-task-definition.json')              // task-definition
+            .mockReturnValueOnce('web')                                                  // container-name
+            .mockReturnValueOnce('nginx:latest')                                         // image
+            .mockReturnValueOnce('')                                                     // environment-variables
+            .mockReturnValueOnce('')                                                     // env-files
+            .mockReturnValueOnce('')                                                     // log Configuration Log Driver
+            .mockReturnValueOnce('')                                                     // log Configuration Options
+            .mockReturnValueOnce('')                                                     // docker labels
+            .mockReturnValueOnce('')                                                     // command
+            .mockReturnValueOnce('')                                                     // task-definition arn
+            .mockReturnValueOnce('')                                                     // task-definition family
+            .mockReturnValueOnce('')                                                     // task-definition revision
+            .mockReturnValueOnce(                                                        // secrets
+                'MY_SECRET=arn:aws:secretsmanager:us-east-1:123456789:secret:my-secret\nDB_PASSWORD=arn:aws:ssm:us-east-1:123456789:parameter/db-password'
+            );
+
+        jest.mock('/hello/secrets-only-task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image"
+                }
+            ]
+        }), { virtual: true });
+
+        await run();
+
+        expect(tmp.fileSync).toHaveBeenNthCalledWith(1, {
+            tmpdir: '/home/runner/work/_temp',
+            prefix: 'task-definition-',
+            postfix: '.json',
+            keep: true,
+            discardDescriptor: true
+        });
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest",
+                        secrets: [
+                            {
+                                name: "MY_SECRET",
+                                valueFrom: "arn:aws:secretsmanager:us-east-1:123456789:secret:my-secret"
+                            },
+                            {
+                                name: "DB_PASSWORD",
+                                valueFrom: "arn:aws:ssm:us-east-1:123456789:parameter/db-password"
+                            }
+                        ]
+                    }
+                ]
+            }, null, 2)
+        );
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
+    });
 });


### PR DESCRIPTION
*Issue #, if available:*

Related: #20

*Description of changes:*

The `secrets` input is nested inside the `if (environmentVariables)` block, causing secrets to be silently ignored when `environment-variables` is not provided.

This PR cherry-picks the fix from @jnyo's #368 and adds a missing test case that verifies secrets render correctly without `environment-variables` being set.

Changes:
- Fix: move `if (secrets)` to be a sibling of `if (environmentVariables)` (authored by @jnyo)
- Test: "renders secrets without environment-variables"

Supersedes #368.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
