### PR TITLE
feat: add task-role-arn and execution-role-arn inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,12 @@ inputs:
   command:
     description: 'The command used by ECS to start the container image'
     required: false
+  task-role-arn:
+    description: 'The full Amazon Resource Name (ARN) of the IAM role that the task can assume. Sets the taskRoleArn field on the task definition.'
+    required: false
+  execution-role-arn:
+    description: 'The full Amazon Resource Name (ARN) of the task execution role. Sets the executionRoleArn field on the task definition.'
+    required: false
   env-files:
     description: 'S3 object arns to set env variables onto the container. You can specify multiple files with multi-line YAML strings.'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,6 +51,8 @@ async function run() {
     const logConfigurationOptions = core.getInput("log-configuration-options", { required: false });
     const dockerLabels = core.getInput('docker-labels', { required: false });
     const command = core.getInput('command', { required: false });
+    const taskRoleArn = core.getInput('task-role-arn', { required: false });
+    const executionRoleArn = core.getInput('execution-role-arn', { required: false });
 
     //New inputs to fetch task definition 
     const taskDefinitionArn = core.getInput('task-definition-arn', { required: false }) || undefined;
@@ -260,6 +262,22 @@ async function run() {
       })
     }
   });
+
+    const arnRegex = /^arn:aws(-cn|-us-gov|-iso|-iso-b|-iso-e|-iso-f)?:iam::[0-9]{12}:role\/.+$/;
+
+    if (taskRoleArn) {
+      if (!arnRegex.test(taskRoleArn)) {
+        throw new Error(`Invalid ARN format for task-role-arn. Expected format: arn:aws:iam::<account-id>:role/<role-name>`);
+      }
+      taskDefContents.taskRoleArn = taskRoleArn;
+    }
+
+    if (executionRoleArn) {
+      if (!arnRegex.test(executionRoleArn)) {
+        throw new Error(`Invalid ARN format for execution-role-arn. Expected format: arn:aws:iam::<account-id>:role/<role-name>`);
+      }
+      taskDefContents.executionRoleArn = executionRoleArn;
+    }
 
     // Write out a new task definition file
     var updatedTaskDefFile = tmp.fileSync({

--- a/index.js
+++ b/index.js
@@ -45,6 +45,8 @@ async function run() {
     const logConfigurationOptions = core.getInput("log-configuration-options", { required: false });
     const dockerLabels = core.getInput('docker-labels', { required: false });
     const command = core.getInput('command', { required: false });
+    const taskRoleArn = core.getInput('task-role-arn', { required: false });
+    const executionRoleArn = core.getInput('execution-role-arn', { required: false });
 
     //New inputs to fetch task definition 
     const taskDefinitionArn = core.getInput('task-definition-arn', { required: false }) || undefined;
@@ -254,6 +256,22 @@ async function run() {
       })
     }
   });
+
+    const arnRegex = /^arn:aws(-cn|-us-gov|-iso|-iso-b|-iso-e|-iso-f)?:iam::[0-9]{12}:role\/.+$/;
+
+    if (taskRoleArn) {
+      if (!arnRegex.test(taskRoleArn)) {
+        throw new Error(`Invalid ARN format for task-role-arn. Expected format: arn:aws:iam::<account-id>:role/<role-name>`);
+      }
+      taskDefContents.taskRoleArn = taskRoleArn;
+    }
+
+    if (executionRoleArn) {
+      if (!arnRegex.test(executionRoleArn)) {
+        throw new Error(`Invalid ARN format for execution-role-arn. Expected format: arn:aws:iam::<account-id>:role/<role-name>`);
+      }
+      taskDefContents.executionRoleArn = executionRoleArn;
+    }
 
     // Write out a new task definition file
     var updatedTaskDefFile = tmp.fileSync({

--- a/index.test.js
+++ b/index.test.js
@@ -47,12 +47,14 @@ describe('Render task definition', () => {
             .mockReturnValueOnce('')                                                    // log Configuration Options
             .mockReturnValueOnce('')                                                    // docker labels
             .mockReturnValueOnce('')                                                    // command
+            .mockReturnValueOnce('')                                                    // task-role-arn
+            .mockReturnValueOnce('')                                                    // execution-role-arn
             .mockReturnValueOnce('')                                                    // task-definition arn
             .mockReturnValueOnce('')                                                    // task-definition family
             .mockReturnValueOnce('')                                                    // task-definition revision
             .mockReturnValueOnce(                                                       // secrets
                 'SSM_SECRET=arn:aws:ssm:region:0123456789:parameter/secret\nSM_SECRET=arn:aws:secretsmanager:us-east-1:0123456789:secret:secretName'
-            );                                          
+            );
 
         process.env = Object.assign(process.env, { GITHUB_WORKSPACE: __dirname });
         process.env = Object.assign(process.env, { RUNNER_TEMP: '/home/runner/work/_temp' });
@@ -263,6 +265,8 @@ describe('Render task definition', () => {
             .mockReturnValueOnce('')                                                      // log Configuration Options
             .mockReturnValueOnce('')                                                      // docker labels
             .mockReturnValueOnce('')                                                      // command
+            .mockReturnValueOnce('')                                                      // task-role-arn
+            .mockReturnValueOnce('')                                                      // execution-role-arn
             .mockReturnValueOnce('')                                                      // task-definition arn
             .mockReturnValueOnce('')                                                      // task-definition family
             .mockReturnValueOnce('')                                                      // task-definition revision
@@ -465,19 +469,21 @@ describe('Render task definition', () => {
     test('error returned for malformatted secret string', async () => {
         core.getInput = jest
             .fn()
-            .mockReturnValueOnce('task-definition.json')
-            .mockReturnValueOnce('web')
-            .mockReturnValueOnce('nginx:latest')
-            .mockReturnValueOnce('EXAMPLE=here')
-            .mockReturnValueOnce('')
-            .mockReturnValueOnce('')
-            .mockReturnValueOnce('')
-            .mockReturnValueOnce('')
-            .mockReturnValueOnce('')
-            .mockReturnValueOnce('')
-            .mockReturnValueOnce('')
-            .mockReturnValueOnce('')
-            .mockReturnValueOnce('SECRET');
+            .mockReturnValueOnce('task-definition.json')                                 // task-definition
+            .mockReturnValueOnce('web')                                                  // container-name
+            .mockReturnValueOnce('nginx:latest')                                         // image
+            .mockReturnValueOnce('EXAMPLE=here')                                         // environment-variables
+            .mockReturnValueOnce('')                                                     // env-files
+            .mockReturnValueOnce('')                                                     // log-configuration-log-driver
+            .mockReturnValueOnce('')                                                     // log-configuration-options
+            .mockReturnValueOnce('')                                                     // docker-labels
+            .mockReturnValueOnce('')                                                     // command
+            .mockReturnValueOnce('')                                                     // task-role-arn
+            .mockReturnValueOnce('')                                                     // execution-role-arn
+            .mockReturnValueOnce('')                                                     // task-definition-arn
+            .mockReturnValueOnce('')                                                     // task-definition-family
+            .mockReturnValueOnce('')                                                     // task-definition-revision
+            .mockReturnValueOnce('SECRET');                                              // secrets
         await run();
 
         expect(core.setFailed).toBeCalledWith(expect.stringContaining(`Cannot parse the secret 'SECRET'`));
@@ -548,6 +554,8 @@ describe('Render task definition', () => {
             .mockReturnValueOnce('')                                                    // log Configuration Options
             .mockReturnValueOnce('')                                                    // Docker Labels
             .mockReturnValueOnce('')                                                    // Command Options 
+            .mockReturnValueOnce('')                                                    // task-role-arn
+            .mockReturnValueOnce('')                                                    // execution-role-arn
             .mockReturnValueOnce('task-definition-arn')                                 // task definition arn
             .mockReturnValueOnce('task-definition-family')                              // task definition family
             .mockReturnValueOnce(0);                                                    // task definition revision
@@ -569,6 +577,8 @@ describe('Render task definition', () => {
             .mockReturnValueOnce('')                           // log Configuration Options
             .mockReturnValueOnce('')                           // Docker Labels
             .mockReturnValueOnce('')                           // Command Options 
+            .mockReturnValueOnce('')                                                    // task-role-arn
+            .mockReturnValueOnce('')                                                    // execution-role-arn
             .mockReturnValueOnce('')                           // task definition arn
             .mockReturnValueOnce("task-definition-family")     // task definition family
             .mockReturnValueOnce(10);                          // task definition revision
@@ -594,6 +604,8 @@ describe('Render task definition', () => {
             .mockReturnValueOnce('')                           // log Configuration Options
             .mockReturnValueOnce('')                           // Docker Labels
             .mockReturnValueOnce('')                           // Command Options 
+            .mockReturnValueOnce('')                                                    // task-role-arn
+            .mockReturnValueOnce('')                                                    // execution-role-arn
             .mockReturnValueOnce('')                           // task definition arn
             .mockReturnValueOnce("task-definition-family")     // task definition family
             .mockReturnValueOnce(0);                           // task definition revision
@@ -620,6 +632,8 @@ describe('Render task definition', () => {
             .mockReturnValueOnce('')                           // log Configuration Options
             .mockReturnValueOnce('')                           // Docker Labels
             .mockReturnValueOnce('')                           // Command Options 
+            .mockReturnValueOnce('')                                                    // task-role-arn
+            .mockReturnValueOnce('')                                                    // execution-role-arn
             .mockReturnValueOnce('task-definition-arn')        // task definition arn
             .mockReturnValueOnce('')                           // task definition family
             .mockReturnValueOnce(0);                           // task definition revision
@@ -646,6 +660,8 @@ describe('Render task definition', () => {
             .mockReturnValueOnce('')                                                    // log Configuration Options
             .mockReturnValueOnce('')                                                    // Docker Labels
             .mockReturnValueOnce('')                                                    // Command Options 
+            .mockReturnValueOnce('')                                                    // task-role-arn
+            .mockReturnValueOnce('')                                                    // execution-role-arn
             .mockReturnValueOnce('task-definition-arn')                                 // task definition arn
             .mockReturnValueOnce('')                                                    // task definition family
             .mockReturnValueOnce(0);                                                    //task definition revision
@@ -669,6 +685,8 @@ describe('Render task definition', () => {
             .mockReturnValueOnce('')                                                    // log Configuration Options
             .mockReturnValueOnce('')                                                    // Docker Labels
             .mockReturnValueOnce('')                                                    // Command Options 
+            .mockReturnValueOnce('')                                                    // task-role-arn
+            .mockReturnValueOnce('')                                                    // execution-role-arn
             .mockReturnValueOnce('task-definition-arn')                                 //task definition arn
             .mockReturnValueOnce('task-definition-family')                              //task definition family
             .mockReturnValueOnce(10);                                                   //task definition revision
@@ -692,6 +710,8 @@ describe('Render task definition', () => {
             .mockReturnValueOnce('')                           // log Configuration Options
             .mockReturnValueOnce('')                           // Docker Labels
             .mockReturnValueOnce('')                           // Command Options 
+            .mockReturnValueOnce('')                                                    // task-role-arn
+            .mockReturnValueOnce('')                                                    // execution-role-arn
             .mockReturnValueOnce('task-definition-arn')        // task definition arn
             .mockReturnValueOnce('task-definition-family')     // task definition family
             .mockReturnValueOnce(0);                           // task definition revision
@@ -717,6 +737,8 @@ describe('Render task definition', () => {
             .mockReturnValueOnce('')                           // log Configuration Options
             .mockReturnValueOnce('')                           // Docker Labels
             .mockReturnValueOnce('')                           // Command Options 
+            .mockReturnValueOnce('')                                                    // task-role-arn
+            .mockReturnValueOnce('')                                                    // execution-role-arn
             .mockReturnValueOnce('')                           // task definition arn
             .mockReturnValueOnce('')                           // task definition family
             .mockReturnValueOnce(10);                          // task definition revision
@@ -1016,6 +1038,8 @@ describe('Render task definition', () => {
             .mockReturnValueOnce('')                                                     // log Configuration Options
             .mockReturnValueOnce('')                                                     // docker labels
             .mockReturnValueOnce('')                                                     // command
+            .mockReturnValueOnce('')                                                     // task-role-arn
+            .mockReturnValueOnce('')                                                     // execution-role-arn
             .mockReturnValueOnce('')                                                     // task-definition arn
             .mockReturnValueOnce('')                                                     // task-definition family
             .mockReturnValueOnce('')                                                     // task-definition revision
@@ -1064,5 +1088,306 @@ describe('Render task definition', () => {
             }, null, 2)
         );
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
+    });
+
+    test('renders a task definition with task role arn', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('/hello/task-role-task-definition.json')                 // task-definition
+            .mockReturnValueOnce('web')                                                  // container-name
+            .mockReturnValueOnce('nginx:latest')                                         // image
+            .mockReturnValueOnce('')                                                     // environment-variables
+            .mockReturnValueOnce('')                                                     // env-files
+            .mockReturnValueOnce('')                                                     // log-configuration-log-driver
+            .mockReturnValueOnce('')                                                     // log-configuration-options
+            .mockReturnValueOnce('')                                                     // docker-labels
+            .mockReturnValueOnce('')                                                     // command
+            .mockReturnValueOnce('arn:aws:iam::123456789012:role/my-task-role')           // task-role-arn
+            .mockReturnValueOnce('')                                                     // execution-role-arn
+            .mockReturnValueOnce('')                                                     // task-definition-arn
+            .mockReturnValueOnce('')                                                     // task-definition-family
+            .mockReturnValueOnce('')                                                     // task-definition-revision
+            .mockReturnValueOnce('');                                                    // secrets
+
+        jest.mock('/hello/task-role-task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image"
+                }
+            ]
+        }), { virtual: true });
+
+        await run();
+
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest"
+                    }
+                ],
+                taskRoleArn: "arn:aws:iam::123456789012:role/my-task-role"
+            }, null, 2)
+        );
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
+    });
+
+    test('renders a task definition with execution role arn', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('/hello/exec-role-task-definition.json')                 // task-definition
+            .mockReturnValueOnce('web')                                                  // container-name
+            .mockReturnValueOnce('nginx:latest')                                         // image
+            .mockReturnValueOnce('')                                                     // environment-variables
+            .mockReturnValueOnce('')                                                     // env-files
+            .mockReturnValueOnce('')                                                     // log-configuration-log-driver
+            .mockReturnValueOnce('')                                                     // log-configuration-options
+            .mockReturnValueOnce('')                                                     // docker-labels
+            .mockReturnValueOnce('')                                                     // command
+            .mockReturnValueOnce('')                                                     // task-role-arn
+            .mockReturnValueOnce('arn:aws:iam::123456789012:role/my-execution-role')      // execution-role-arn
+            .mockReturnValueOnce('')                                                     // task-definition-arn
+            .mockReturnValueOnce('')                                                     // task-definition-family
+            .mockReturnValueOnce('')                                                     // task-definition-revision
+            .mockReturnValueOnce('');                                                    // secrets
+
+        jest.mock('/hello/exec-role-task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image"
+                }
+            ]
+        }), { virtual: true });
+
+        await run();
+
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest"
+                    }
+                ],
+                executionRoleArn: "arn:aws:iam::123456789012:role/my-execution-role"
+            }, null, 2)
+        );
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
+    });
+
+    test('renders a task definition with both task role and execution role arns', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('/hello/both-roles-task-definition.json')                // task-definition
+            .mockReturnValueOnce('web')                                                  // container-name
+            .mockReturnValueOnce('nginx:latest')                                         // image
+            .mockReturnValueOnce('')                                                     // environment-variables
+            .mockReturnValueOnce('')                                                     // env-files
+            .mockReturnValueOnce('')                                                     // log-configuration-log-driver
+            .mockReturnValueOnce('')                                                     // log-configuration-options
+            .mockReturnValueOnce('')                                                     // docker-labels
+            .mockReturnValueOnce('')                                                     // command
+            .mockReturnValueOnce('arn:aws:iam::123456789012:role/my-task-role')           // task-role-arn
+            .mockReturnValueOnce('arn:aws:iam::123456789012:role/my-execution-role')      // execution-role-arn
+            .mockReturnValueOnce('')                                                     // task-definition-arn
+            .mockReturnValueOnce('')                                                     // task-definition-family
+            .mockReturnValueOnce('')                                                     // task-definition-revision
+            .mockReturnValueOnce('');                                                    // secrets
+
+        jest.mock('/hello/both-roles-task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image"
+                }
+            ]
+        }), { virtual: true });
+
+        await run();
+
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest"
+                    }
+                ],
+                taskRoleArn: "arn:aws:iam::123456789012:role/my-task-role",
+                executionRoleArn: "arn:aws:iam::123456789012:role/my-execution-role"
+            }, null, 2)
+        );
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition', 'new-task-def-file-name');
+    });
+
+    test('renders a task definition with role arn containing a path', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('/hello/path-role-task-definition.json')                 // task-definition
+            .mockReturnValueOnce('web')                                                  // container-name
+            .mockReturnValueOnce('nginx:latest')                                         // image
+            .mockReturnValueOnce('')                                                     // environment-variables
+            .mockReturnValueOnce('')                                                     // env-files
+            .mockReturnValueOnce('')                                                     // log-configuration-log-driver
+            .mockReturnValueOnce('')                                                     // log-configuration-options
+            .mockReturnValueOnce('')                                                     // docker-labels
+            .mockReturnValueOnce('')                                                     // command
+            .mockReturnValueOnce('arn:aws:iam::123456789012:role/path/to/my-task-role')   // task-role-arn
+            .mockReturnValueOnce('')                                                     // execution-role-arn
+            .mockReturnValueOnce('')                                                     // task-definition-arn
+            .mockReturnValueOnce('')                                                     // task-definition-family
+            .mockReturnValueOnce('')                                                     // task-definition-revision
+            .mockReturnValueOnce('');                                                    // secrets
+
+        jest.mock('/hello/path-role-task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image"
+                }
+            ]
+        }), { virtual: true });
+
+        await run();
+
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest"
+                    }
+                ],
+                taskRoleArn: "arn:aws:iam::123456789012:role/path/to/my-task-role"
+            }, null, 2)
+        );
+    });
+
+    test('renders a task definition with role arn for aws-cn partition', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('/hello/cn-role-task-definition.json')                   // task-definition
+            .mockReturnValueOnce('web')                                                  // container-name
+            .mockReturnValueOnce('nginx:latest')                                         // image
+            .mockReturnValueOnce('')                                                     // environment-variables
+            .mockReturnValueOnce('')                                                     // env-files
+            .mockReturnValueOnce('')                                                     // log-configuration-log-driver
+            .mockReturnValueOnce('')                                                     // log-configuration-options
+            .mockReturnValueOnce('')                                                     // docker-labels
+            .mockReturnValueOnce('')                                                     // command
+            .mockReturnValueOnce('arn:aws-cn:iam::123456789012:role/my-task-role')        // task-role-arn
+            .mockReturnValueOnce('')                                                     // execution-role-arn
+            .mockReturnValueOnce('')                                                     // task-definition-arn
+            .mockReturnValueOnce('')                                                     // task-definition-family
+            .mockReturnValueOnce('')                                                     // task-definition-revision
+            .mockReturnValueOnce('');                                                    // secrets
+
+        jest.mock('/hello/cn-role-task-definition.json', () => ({
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: "web",
+                    image: "some-other-image"
+                }
+            ]
+        }), { virtual: true });
+
+        await run();
+
+        expect(fs.writeFileSync).toHaveBeenNthCalledWith(1, 'new-task-def-file-name',
+            JSON.stringify({
+                family: 'task-def-family',
+                containerDefinitions: [
+                    {
+                        name: "web",
+                        image: "nginx:latest"
+                    }
+                ],
+                taskRoleArn: "arn:aws-cn:iam::123456789012:role/my-task-role"
+            }, null, 2)
+        );
+    });
+
+    test('error returned for invalid task role arn format', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('task-definition.json')                                 // task-definition
+            .mockReturnValueOnce('web')                                                  // container-name
+            .mockReturnValueOnce('nginx:latest')                                         // image
+            .mockReturnValueOnce('')                                                     // environment-variables
+            .mockReturnValueOnce('')                                                     // env-files
+            .mockReturnValueOnce('')                                                     // log-configuration-log-driver
+            .mockReturnValueOnce('')                                                     // log-configuration-options
+            .mockReturnValueOnce('')                                                     // docker-labels
+            .mockReturnValueOnce('')                                                     // command
+            .mockReturnValueOnce('not-a-valid-arn')                                      // task-role-arn
+            .mockReturnValueOnce('')                                                     // execution-role-arn
+            .mockReturnValueOnce('')                                                     // task-definition-arn
+            .mockReturnValueOnce('')                                                     // task-definition-family
+            .mockReturnValueOnce('')                                                     // task-definition-revision
+            .mockReturnValueOnce('');                                                    // secrets
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid ARN format for task-role-arn. Expected format: arn:aws:iam::<account-id>:role/<role-name>');
+    });
+
+    test('error returned for invalid execution role arn format', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('task-definition.json')                                 // task-definition
+            .mockReturnValueOnce('web')                                                  // container-name
+            .mockReturnValueOnce('nginx:latest')                                         // image
+            .mockReturnValueOnce('')                                                     // environment-variables
+            .mockReturnValueOnce('')                                                     // env-files
+            .mockReturnValueOnce('')                                                     // log-configuration-log-driver
+            .mockReturnValueOnce('')                                                     // log-configuration-options
+            .mockReturnValueOnce('')                                                     // docker-labels
+            .mockReturnValueOnce('')                                                     // command
+            .mockReturnValueOnce('')                                                     // task-role-arn
+            .mockReturnValueOnce('arn:aws:iam::12345:role/too-short-account')             // execution-role-arn
+            .mockReturnValueOnce('')                                                     // task-definition-arn
+            .mockReturnValueOnce('')                                                     // task-definition-family
+            .mockReturnValueOnce('')                                                     // task-definition-revision
+            .mockReturnValueOnce('');                                                    // secrets
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid ARN format for execution-role-arn. Expected format: arn:aws:iam::<account-id>:role/<role-name>');
+    });
+
+    test('error returned for arn with wrong service', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('task-definition.json')                                 // task-definition
+            .mockReturnValueOnce('web')                                                  // container-name
+            .mockReturnValueOnce('nginx:latest')                                         // image
+            .mockReturnValueOnce('')                                                     // environment-variables
+            .mockReturnValueOnce('')                                                     // env-files
+            .mockReturnValueOnce('')                                                     // log-configuration-log-driver
+            .mockReturnValueOnce('')                                                     // log-configuration-options
+            .mockReturnValueOnce('')                                                     // docker-labels
+            .mockReturnValueOnce('')                                                     // command
+            .mockReturnValueOnce('arn:aws:s3::123456789012:role/my-role')                 // task-role-arn
+            .mockReturnValueOnce('')                                                     // execution-role-arn
+            .mockReturnValueOnce('')                                                     // task-definition-arn
+            .mockReturnValueOnce('')                                                     // task-definition-family
+            .mockReturnValueOnce('')                                                     // task-definition-revision
+            .mockReturnValueOnce('');                                                    // secrets
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Invalid ARN format for task-role-arn. Expected format: arn:aws:iam::<account-id>:role/<role-name>');
     });
 });


### PR DESCRIPTION
## Summary

- Adds `task-role-arn` and `execution-role-arn` optional inputs to dynamically set `taskRoleArn` and `executionRoleArn` on the rendered task definition
- Includes ARN format validation (regex) supporting all AWS partitions: `aws`, `aws-cn`, `aws-us-gov`, `aws-iso`, `aws-iso-b`, `aws-iso-e`, `aws-iso-f`
- Sets role ARNs at the task definition level (not container level), matching the ECS API schema

Closes #378, closes #183

## Motivation

Users need to pass IAM role ARNs via GitHub Secrets rather than hardcoding them in task definition JSON files (security concern raised in #183). This also addresses the review feedback on PR #372 which requested ARN validation.

## Test plan

- [ ] Existing tests updated with new mock positions for the two additional `getInput` calls
- [ ] New tests: task role ARN only, execution role ARN only, both together
- [ ] New tests: role ARN with path prefix (`/path/to/role`)
- [ ] New tests: `aws-cn` partition ARN
- [ ] New tests: invalid ARN format (garbage string, wrong service, short account ID)
- [ ] Verify `npm test` passes locally
- [ ] Verify `npm run package` rebuilds dist/ cleanly