### PR TITLE
fix: upgrade tmp to 0.2.7 (CVE-2026-49982)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@actions/core": "^2.0.2",
         "@aws-sdk/client-ecs": "^3.1077.0",
-        "tmp": "^0.2.6"
+        "tmp": "^0.2.7"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.38.4",
@@ -4397,9 +4397,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@actions/core": "^2.0.2",
     "@aws-sdk/client-ecs": "^3.1077.0",
-    "tmp": "^0.2.6"
+    "tmp": "^0.2.7"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.38.4",


### PR DESCRIPTION
## Summary
Upgrade tmp from 0.2.6 to 0.2.7 to fix CVE-2026-49982.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-49982 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-49982` |
| **File** | `package-lock.json` (dependency: `tmp`) |
| **Assessment** | Likely exploitable |

**Description**: tmp: Type-confusion bypass of _assertPath allows path traversal via non-string prefix/postfix/template

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-49982` flagged this pattern.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
